### PR TITLE
Reorganise source for eventual cli app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea
 montagu-reports
+tests/example/.outpack/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1140,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
-name = "outpack_server"
+name = "outpack"
 version = "0.2.0"
 dependencies = [
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,10 @@
 [package]
-name = "outpack_server"
+name = "outpack"
 version = "0.2.0"
 edition = "2021"
 include = ["schema/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[[bin]]
-name = "outpack_server"
-path = "src/main.rs"
-
-[lib]
-name = "outpack_server"
-path = "src/lib.rs"
 
 [dependencies]
 rocket = { version = "0.5.0-rc.2", features = ["json"] }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# outpack_server
+# outpack
 
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 
-Rust implementation of the `outpack` HTTP API.
+Rust implementation of `outpack`. This crate provides two binaries:
 
-## Usage
+* `outpack`: an outpack CLI, designed to interact with any outpack archive
+* `outpack_server`: an HTTP server, implementing the outpack API
+
+## Cli usage
+
+```
+cargo run --bin outpack -- --root <path>
+```
+
+## Server usage
 
 Start with `cargo run --bin outpack_server -- --root <path>`. Or build the binary
 with `cargo build` and run directly with `target/debug/outpack_server run --root <path>`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,28 @@
 # outpack_server
+
 [![Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.](https://www.repostatus.org/badges/latest/concept.svg)](https://www.repostatus.org/#concept)
 
 Rust implementation of the `outpack` HTTP API.
 
 ## Usage
-Start with `cargo run -- --root <path>`. Or build the binary
+
+Start with `cargo run --bin outpack_server -- --root <path>`. Or build the binary
 with `cargo build` and run directly with `target/debug/outpack_server run --root <path>`
 
 E.g.
 
-```cargo run -- --root tests/example```
+```
+cargo run --bin outpack_server -- --root tests/example
+```
 
 ## Usage of docker image
 
-```docker run --name outpack_server -v /full/path/to/root:/outpack -p 8000:8000 -d mrcide/outpack_server:main```
+```
+docker run --name outpack_server -v /full/path/to/root:/outpack -p 8000:8000 -d mrcide/outpack_server:main
+```
 
 ## Schema
+
 The outpack schema is imported into this package by running `./scripts/import_schema`,
 and needs to be kept manually up to date by re-running that script as needed.
 
@@ -146,10 +153,13 @@ e.g. `/checksum?alg=md5`.
 ```
 
 ## GET /metadata/\<id\>/text
+
 Returns the same as `GET /metadata/<id>/json` but just the data as plain text.
 
 ## GET /file/\<hash\>
+
 Downloads the file with the provided hash. 404 if it doesn't exist.
 
 ## License
+
 MIT © Imperial College of Science, Technology and Medicine

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,83 @@
+use std::io::{ErrorKind};
+use rocket::serde::json::{Json};
+use rocket::{Build, catch, catchers, Request, Rocket, routes};
+use rocket::State;
+
+use crate::responses;
+use crate::config;
+use crate::location;
+use crate::metadata;
+use crate::store;
+
+use responses::{FailResponse, OutpackError, OutpackSuccess};
+use crate::outpack_file::OutpackFile;
+
+type OutpackResult<T> = Result<OutpackSuccess<T>, OutpackError>;
+
+#[catch(500)]
+fn internal_error(_req: &Request) -> Json<FailResponse> {
+    Json(FailResponse::from(OutpackError {
+        error: String::from("UNKNOWN_ERROR"),
+        detail: String::from("Something went wrong"),
+        kind: Some(ErrorKind::Other),
+    }))
+}
+
+#[catch(404)]
+fn not_found(_req: &Request) -> Json<FailResponse> {
+    Json(FailResponse::from(OutpackError {
+        error: String::from("NOT_FOUND"),
+        detail: String::from("This route does not exist"),
+        kind: Some(ErrorKind::NotFound),
+    }))
+}
+
+#[rocket::get("/")]
+fn index(root: &State<String>) -> OutpackResult<config::Root> {
+    config::read_config(root)
+        .map(|r| config::Root::new(r.schema_version))
+        .map_err(|e| OutpackError::from(e))
+        .map(|r| OutpackSuccess::from(r))
+}
+
+#[rocket::get("/metadata/list")]
+fn list_metadata(root: &State<String>) -> OutpackResult<Vec<location::LocationEntry>> {
+    location::read_locations(root)
+        .map_err(|e| OutpackError::from(e))
+        .map(|r| OutpackSuccess::from(r))
+}
+
+#[rocket::get("/metadata/<id>/json")]
+fn get_metadata(root: &State<String>, id: String) -> OutpackResult<serde_json::Value> {
+    metadata::get_metadata(root, &id)
+        .map_err(|e| OutpackError::from(e))
+        .map(|r| OutpackSuccess::from(r))
+}
+
+#[rocket::get("/metadata/<id>/text")]
+fn get_metadata_raw(root: &State<String>, id: String) -> Result<String, OutpackError> {
+    metadata::get_metadata_text(root, &id)
+        .map_err(|e| OutpackError::from(e))
+}
+
+#[rocket::get("/file/<hash>")]
+pub async fn get_file(root: &State<String>, hash: String) -> Result<OutpackFile, OutpackError> {
+    let path = store::file_path(&root, &hash);
+    OutpackFile::open(hash, path?).await
+        .map_err(|e| OutpackError::from(e))
+}
+
+#[rocket::get("/checksum?<alg>")]
+pub async fn get_checksum(root: &State<String>, alg: Option<String>) -> OutpackResult<String> {
+    metadata::get_ids_digest(&root, alg)
+        .map_err(|e| OutpackError::from(e))
+        .map(|r| OutpackSuccess::from(r))
+}
+
+pub fn api(root: String) -> Rocket<Build> {
+    rocket::build()
+        .manage(root)
+        .register("/", catchers![internal_error, not_found])
+        .mount("/", routes![index, list_metadata, get_metadata,
+            get_metadata_raw, get_file, get_checksum])
+}

--- a/src/bin/outpack.rs
+++ b/src/bin/outpack.rs
@@ -1,0 +1,38 @@
+extern crate core;
+
+use getopts::Options;
+use std::env;
+
+fn print_usage(program: &str, opts: Options) {
+    let brief = format!("Usage: {} [options]", program);
+    print!("{}", opts.usage(&brief));
+}
+
+fn parse_args(args: &[String]) -> Option<String> {
+    let program = args[0].clone();
+    let mut opts = Options::new();
+    opts.reqopt("r", "root", "outpack root path (required)", ".");
+    let matches = match opts.parse(&args[1..]) {
+        Ok(m) => { m }
+        Err(f) => {
+            print_usage(&program, opts);
+            panic!("{}", f.to_string())
+        }
+    };
+    Some(matches.opt_str("r").unwrap())
+}
+
+fn main() {
+    let args = env::args().collect::<Vec<_>>();
+    let root = parse_args(&args);
+    if root.is_some() {
+        let root_path = root.unwrap();
+        let cfg = outpack::config::read_config(&root_path)
+            .unwrap_or_else(|error| {
+                panic!("Could not open outpack root at {}: {:?}",
+                       root_path, error);
+            });
+        println!("Root '{}' has schema version '{}'",
+                 root_path, cfg.schema_version);
+    }
+}

--- a/src/bin/outpack_server.rs
+++ b/src/bin/outpack_server.rs
@@ -28,7 +28,7 @@ async fn start_app(root_path: String) -> Result<(), rocket::Error> {
     if !Path::new(&root_path).join(".outpack").exists() {
         panic!("Outpack root not found at {}", root_path)
     }
-    outpack_server::api(root_path).launch().await;
+    outpack::api(root_path).launch().await;
     Ok(())
 }
 

--- a/src/bin/outpack_server.rs
+++ b/src/bin/outpack_server.rs
@@ -1,5 +1,3 @@
-extern crate core;
-
 use getopts::Options;
 use std::env;
 use std::path::Path;
@@ -28,7 +26,7 @@ async fn start_app(root_path: String) -> Result<(), rocket::Error> {
     if !Path::new(&root_path).join(".outpack").exists() {
         panic!("Outpack root not found at {}", root_path)
     }
-    outpack::api(root_path).launch().await;
+    outpack::api::api(root_path).launch().await;
     Ok(())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,85 +1,9 @@
-use std::io::{ErrorKind};
-use rocket::serde::json::{Json};
-use rocket::{Build, catch, catchers, Request, Rocket, routes};
-use rocket::State;
-
 pub mod config;
+pub mod api;
+
 mod responses;
 mod location;
 mod metadata;
 mod store;
 mod outpack_file;
 mod hash;
-
-use responses::{FailResponse, OutpackError, OutpackSuccess};
-use crate::outpack_file::OutpackFile;
-
-type OutpackResult<T> = Result<OutpackSuccess<T>, OutpackError>;
-
-#[catch(500)]
-fn internal_error(_req: &Request) -> Json<FailResponse> {
-    Json(FailResponse::from(OutpackError {
-        error: String::from("UNKNOWN_ERROR"),
-        detail: String::from("Something went wrong"),
-        kind: Some(ErrorKind::Other),
-    }))
-}
-
-#[catch(404)]
-fn not_found(_req: &Request) -> Json<FailResponse> {
-    Json(FailResponse::from(OutpackError {
-        error: String::from("NOT_FOUND"),
-        detail: String::from("This route does not exist"),
-        kind: Some(ErrorKind::NotFound),
-    }))
-}
-
-#[rocket::get("/")]
-fn index(root: &State<String>) -> OutpackResult<config::Root> {
-    config::read_config(root)
-        .map(|r| config::Root::new(r.schema_version))
-        .map_err(|e| OutpackError::from(e))
-        .map(|r| OutpackSuccess::from(r))
-}
-
-#[rocket::get("/metadata/list")]
-fn list_metadata(root: &State<String>) -> OutpackResult<Vec<location::LocationEntry>> {
-    location::read_locations(root)
-        .map_err(|e| OutpackError::from(e))
-        .map(|r| OutpackSuccess::from(r))
-}
-
-#[rocket::get("/metadata/<id>/json")]
-fn get_metadata(root: &State<String>, id: String) -> OutpackResult<serde_json::Value> {
-    metadata::get_metadata(root, &id)
-        .map_err(|e| OutpackError::from(e))
-        .map(|r| OutpackSuccess::from(r))
-}
-
-#[rocket::get("/metadata/<id>/text")]
-fn get_metadata_raw(root: &State<String>, id: String) -> Result<String, OutpackError> {
-    metadata::get_metadata_text(root, &id)
-        .map_err(|e| OutpackError::from(e))
-}
-
-#[rocket::get("/file/<hash>")]
-pub async fn get_file(root: &State<String>, hash: String) -> Result<OutpackFile, OutpackError> {
-    let path = store::file_path(&root, &hash);
-    OutpackFile::open(hash, path?).await
-        .map_err(|e| OutpackError::from(e))
-}
-
-#[rocket::get("/checksum?<alg>")]
-pub async fn get_checksum(root: &State<String>, alg: Option<String>) -> OutpackResult<String> {
-    metadata::get_ids_digest(&root, alg)
-        .map_err(|e| OutpackError::from(e))
-        .map(|r| OutpackSuccess::from(r))
-}
-
-pub fn api(root: String) -> Rocket<Build> {
-    rocket::build()
-        .manage(root)
-        .register("/", catchers![internal_error, not_found])
-        .mount("/", routes![index, list_metadata, get_metadata,
-            get_metadata_raw, get_file, get_checksum])
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use rocket::serde::json::{Json};
 use rocket::{Build, catch, catchers, Request, Rocket, routes};
 use rocket::State;
 
-mod config;
+pub mod config;
 mod responses;
 mod location;
 mod metadata;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 #[test]
 fn can_get_index() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/").dispatch();
 
@@ -23,7 +23,7 @@ fn can_get_index() {
 
 #[test]
 fn error_if_cant_get_index() {
-    let rocket = outpack::api(String::from("badlocation"));
+    let rocket = outpack::api::api(String::from("badlocation"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/").dispatch();
 
@@ -36,7 +36,7 @@ fn error_if_cant_get_index() {
 
 #[test]
 fn can_get_checksum() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/checksum").dispatch();
 
@@ -59,7 +59,7 @@ fn can_get_checksum() {
 
 #[test]
 fn can_list_metadata() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
 
@@ -84,7 +84,7 @@ fn can_list_metadata() {
 
 #[test]
 fn handles_metadata_errors() {
-    let rocket = outpack::api(String::from("tests/bad-example"));
+    let rocket = outpack::api::api(String::from("tests/bad-example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -96,7 +96,7 @@ fn handles_metadata_errors() {
 
 #[test]
 fn can_get_metadata_json() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/20170818-164847-7574883b/json").dispatch();
 
@@ -109,7 +109,7 @@ fn can_get_metadata_json() {
 
 #[test]
 fn can_get_metadata_text() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/20170818-164847-7574883b/text").dispatch();
 
@@ -124,7 +124,7 @@ fn can_get_metadata_text() {
 
 #[test]
 fn returns_404_if_packet_not_found() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/bad-id/json").dispatch();
 
@@ -137,7 +137,7 @@ fn returns_404_if_packet_not_found() {
 
 #[test]
 fn can_get_file() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let hash = "sha256:b189579a9326f585d308304bd9e03326be5d395ac71b31df359ab8bac408d248";
     let response = client.get(format!("/file/{}", hash)).dispatch();
@@ -160,7 +160,7 @@ fn can_get_file() {
 
 #[test]
 fn returns_404_if_file_not_found() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let hash = "sha256:123456";
     let response = client.get(format!("/file/{}", hash)).dispatch();
@@ -174,7 +174,7 @@ fn returns_404_if_file_not_found() {
 
 #[test]
 fn catches_arbitrary_404() {
-    let rocket = outpack::api(String::from("tests/example"));
+    let rocket = outpack::api::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/badurl").dispatch();
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 #[test]
 fn can_get_index() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/").dispatch();
 
@@ -23,7 +23,7 @@ fn can_get_index() {
 
 #[test]
 fn error_if_cant_get_index() {
-    let rocket = outpack_server::api(String::from("badlocation"));
+    let rocket = outpack::api(String::from("badlocation"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/").dispatch();
 
@@ -36,7 +36,7 @@ fn error_if_cant_get_index() {
 
 #[test]
 fn can_get_checksum() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/checksum").dispatch();
 
@@ -59,7 +59,7 @@ fn can_get_checksum() {
 
 #[test]
 fn can_list_metadata() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
 
@@ -84,7 +84,7 @@ fn can_list_metadata() {
 
 #[test]
 fn handles_metadata_errors() {
-    let rocket = outpack_server::api(String::from("tests/bad-example"));
+    let rocket = outpack::api(String::from("tests/bad-example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -96,7 +96,7 @@ fn handles_metadata_errors() {
 
 #[test]
 fn can_get_metadata_json() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/20170818-164847-7574883b/json").dispatch();
 
@@ -109,7 +109,7 @@ fn can_get_metadata_json() {
 
 #[test]
 fn can_get_metadata_text() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/20170818-164847-7574883b/text").dispatch();
 
@@ -124,7 +124,7 @@ fn can_get_metadata_text() {
 
 #[test]
 fn returns_404_if_packet_not_found() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/bad-id/json").dispatch();
 
@@ -137,7 +137,7 @@ fn returns_404_if_packet_not_found() {
 
 #[test]
 fn can_get_file() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let hash = "sha256:b189579a9326f585d308304bd9e03326be5d395ac71b31df359ab8bac408d248";
     let response = client.get(format!("/file/{}", hash)).dispatch();
@@ -160,7 +160,7 @@ fn can_get_file() {
 
 #[test]
 fn returns_404_if_file_not_found() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let hash = "sha256:123456";
     let response = client.get(format!("/file/{}", hash)).dispatch();
@@ -174,7 +174,7 @@ fn returns_404_if_file_not_found() {
 
 #[test]
 fn catches_arbitrary_404() {
-    let rocket = outpack_server::api(String::from("tests/example"));
+    let rocket = outpack::api(String::from("tests/example"));
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/badurl").dispatch();
 


### PR DESCRIPTION
This PR reorganises the source - this builds on the pattern that was already most there.

* we now build two binaries - `outpack_server` and `outpack`; the former is the http api and the latter is a smaller cli app that we will expand
* moved the api code into its own file and reorganised the lib.rs file