### PR TITLE
mrc-4335: Add parameters search into outpack rust querying

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -5,6 +5,7 @@ use std::str::FromStr;
 use cached::cached_result;
 use crate::config::HashAlgorithm;
 use crate::location::read_locations;
+use std::collections::HashMap;
 
 use super::config;
 use super::hash;
@@ -15,7 +16,7 @@ pub struct Packet {
     pub id: String,
     pub name: String,
     pub custom: Option<serde_json::Value>,
-    pub parameters: Option<serde_json::Value>,
+    pub parameters: Option<HashMap<String, String>>,
 }
 
 cached_result! {
@@ -180,5 +181,22 @@ mod tests {
         assert!(ids.iter().any(|e| e == "20170818-164830-33e0ab01"));
         assert!(ids.iter().any(|e| e == "20170818-164847-7574883b"));
         assert!(ids.iter().any(|e| e == "20180818-164043-7cdcde4b"));
+    }
+
+    #[test]
+    fn packets_have_parameters() {
+        let all_packets = get_metadata_from_date("tests/example", None)
+            .unwrap();
+        assert_eq!(all_packets.len(), 3);
+
+        let disease_param = HashMap::from([
+            (String::from("disease"), String::from("YF"))
+        ]);
+        assert_eq!(all_packets[0].id, "20170818-164830-33e0ab01");
+        assert_eq!(all_packets[0].parameters, Some(disease_param.clone()));
+        assert_eq!(all_packets[1].id, "20170818-164847-7574883b");
+        assert!(all_packets[1].parameters.is_none());
+        assert_eq!(all_packets[2].id, "20180818-164043-7cdcde4b");
+        assert_eq!(all_packets[2].parameters, Some(disease_param));
     }
 }

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -11,9 +11,16 @@ funcNames          = _{ latest }
 latest             =  { "latest" }
 
 infixExpression = { firstArg ~ infixFunction ~ secondArg }
-firstArg        = { "id" | "name" }
+firstArg        = { lookup }
 secondArg       = { string }
 infixFunction   = { char* }
+
+lookup   = _{ lookupId | lookupName | lookupParam }
+lookupId = { "id" }
+lookupName = { "name" }
+lookupParam = { "parameter:" ~ lookupParamName }
+// Strings and numerics!
+lookupParamName = { ASCII_ALPHANUMERIC* }
 
 string = ${ "\"" ~ inner ~ "\"" }
 // Contents of string including double quotes

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -19,7 +19,6 @@ lookup   = _{ lookupId | lookupName | lookupParam }
 lookupId = { "id" }
 lookupName = { "name" }
 lookupParam = { "parameter:" ~ lookupParamName }
-// Strings and numerics!
 lookupParamName = { ASCII_ALPHANUMERIC* }
 
 string = ${ "\"" ~ inner ~ "\"" }

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -34,7 +34,7 @@ fn packet_has_param(packet: &Packet, key: &str, value: &str) -> bool {
     match &packet.parameters {
         Some(params) => {
             if let Some(existing_value) = params.get(key) {
-                *existing_value == value
+                existing_value == value
             } else {
                 false
             }

--- a/src/query/query_parse.rs
+++ b/src/query/query_parse.rs
@@ -43,9 +43,13 @@ fn parse_query_content(query: pest::iterators::Pair<Rule>) -> Result<QueryNode, 
             let second_arg = infix.next().unwrap();
             match infix_function.as_str() {
                 "==" => {
-                    let lookup_type = match first_arg.as_str() {
-                        "id" => LookupLhs::Id,
-                        "name" => LookupLhs::Name,
+                    let lhs = get_first_inner_pair(first_arg);
+                    let lookup_type = match lhs.as_rule() {
+                        Rule::lookupId => LookupLhs::Id,
+                        Rule::lookupName => LookupLhs::Name,
+                        Rule::lookupParam => {
+                            LookupLhs::Parameter(get_first_inner_pair(lhs).as_str())
+                        }
                         _ => unreachable!(),
                     };
                     let search_term = get_string_inner(get_first_inner_pair(second_arg));
@@ -135,6 +139,14 @@ mod tests {
         assert!(matches!(res, QueryNode::Lookup(LookupLhs::Id, "12 3")));
         let res = parse_query("name == \"123\"").unwrap();
         assert!(matches!(res, QueryNode::Lookup(LookupLhs::Name, "123")));
+        let res = parse_query("parameter:x == \"foo\"").unwrap();
+        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x"), "foo")));
+        let res = parse_query("parameter:x==\"foo\"").unwrap();
+        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x"), "foo")));
+        let res = parse_query("parameter:longer==\"foo\"").unwrap();
+        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("longer"), "foo")));
+        let res = parse_query("parameter:x123==\"foo\"").unwrap();
+        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x123"), "foo")));
         let res = parse_query("latest(id == \"123\")").unwrap();
         match res {
             QueryNode::Latest(Some(value)) => {

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -1,11 +1,12 @@
 #[derive(Debug)]
-pub enum LookupLhs {
+pub enum LookupLhs<'a> {
     Name,
     Id,
+    Parameter(&'a str)
 }
 
 #[derive(Debug)]
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
-    Lookup(LookupLhs, &'a str),
+    Lookup(LookupLhs<'a>, &'a str),
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -112,8 +112,7 @@ fn can_list_metadata() {
 
     assert_eq!(entries[0].get("id").unwrap().as_str().unwrap(), "20170818-164830-33e0ab01");
     assert_eq!(entries[0].get("name").unwrap().as_str().unwrap(), "modup-201707-queries1");
-    assert_eq!(entries[0].get("parameters").unwrap()
-                   .as_object().unwrap().get("disease").unwrap().as_str().unwrap(), "YF");
+    assert_eq!(entries[0].get("parameters").unwrap().get("disease").unwrap(), "YF");
     assert_eq!(entries[0].get("custom").unwrap()
                    .as_object().unwrap().get("orderly").unwrap()
                    .as_object().unwrap().get("displayname").unwrap().as_str().unwrap(),

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -78,3 +78,17 @@ fn can_get_latest_of_lookup() {
         outpack::query::run_query(root_path, "latest(name == \"modup-201707-queries1\")").unwrap();
     assert_eq!(packets, "20180818-164043-7cdcde4b");
 }
+
+#[test]
+fn can_get_packet_by_parameter() {
+    let root_path = "tests/example";
+    let packets =
+        outpack::query::run_query(root_path, "parameter:disease == \"YF\"").unwrap();
+    assert_eq!(packets, "20170818-164830-33e0ab01\n20180818-164043-7cdcde4b");
+    let packets =
+        outpack::query::run_query(root_path, "latest(parameter:disease == \"YF\")").unwrap();
+    assert_eq!(packets, "20180818-164043-7cdcde4b");
+    let packets =
+        outpack::query::run_query(root_path, "latest(parameter:unknown == \"YF\")").unwrap();
+    assert_eq!(packets, "Found no packets");
+}


### PR DESCRIPTION
Note this will only work for string types at the moment, will add querying for numeric types in a separate PR.

But after this PR you can now run a query like
```
parameter:disease == "YF"
```

or 

```
latest(parameter:iso3 == "MWI")
```