### PR TITLE
Revert "mrc-4335: Add parameters search into outpack rust querying"

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{fs, io};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::str::{FromStr};
 use cached::cached_result;
@@ -17,7 +17,7 @@ pub struct Packet {
     pub id: String,
     pub name: String,
     pub custom: Option<serde_json::Value>,
-    pub parameters: Option<HashMap<String, String>>,
+    pub parameters: Option<serde_json::Value>,
 }
 
 cached_result! {
@@ -254,22 +254,5 @@ mod tests {
                                        "20170818-164830-33e0ab0".to_string()],
                                   None).map_err(|e| e.kind());
         assert_eq!(Err(io::ErrorKind::InvalidInput), res);
-    }
-
-    #[test]
-    fn packets_have_parameters() {
-        let all_packets = get_metadata_from_date("tests/example", None)
-            .unwrap();
-        assert_eq!(all_packets.len(), 3);
-
-        let disease_param = HashMap::from([
-            (String::from("disease"), String::from("YF"))
-        ]);
-        assert_eq!(all_packets[0].id, "20170818-164830-33e0ab01");
-        assert_eq!(all_packets[0].parameters, Some(disease_param.clone()));
-        assert_eq!(all_packets[1].id, "20170818-164847-7574883b");
-        assert!(all_packets[1].parameters.is_none());
-        assert_eq!(all_packets[2].id, "20180818-164043-7cdcde4b");
-        assert_eq!(all_packets[2].parameters, Some(disease_param));
     }
 }

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -11,15 +11,9 @@ funcNames          = _{ latest }
 latest             =  { "latest" }
 
 infixExpression = { firstArg ~ infixFunction ~ secondArg }
-firstArg        = { lookup }
+firstArg        = { "id" | "name" }
 secondArg       = { string }
 infixFunction   = { char* }
-
-lookup   = _{ lookupId | lookupName | lookupParam }
-lookupId = { "id" }
-lookupName = { "name" }
-lookupParam = { "parameter:" ~ lookupParamName }
-lookupParamName = { ASCII_ALPHANUMERIC* }
 
 string = ${ "\"" ~ inner ~ "\"" }
 // Contents of string including double quotes

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -30,19 +30,6 @@ fn eval_latest<'a>(
     }
 }
 
-fn packet_has_param(packet: &Packet, key: &str, value: &str) -> bool {
-    match &packet.parameters {
-        Some(params) => {
-            if let Some(existing_value) = params.get(key) {
-                existing_value == value
-            } else {
-                false
-            }
-        },
-        None => false
-    }
-}
-
 fn eval_lookup<'a>(
     index: &'a Index,
     lookup_field: LookupLhs,
@@ -54,7 +41,6 @@ fn eval_lookup<'a>(
         .filter(|packet| match lookup_field {
             LookupLhs::Id => packet.id == value,
             LookupLhs::Name => packet.name == value,
-            LookupLhs::Parameter(param_name) => packet_has_param(packet, param_name, value)
         })
         .collect())
 }
@@ -84,14 +70,6 @@ mod tests {
         );
 
         let query = QueryNode::Lookup(LookupLhs::Id, "123");
-        let res = eval_query(&index, query).unwrap();
-        assert_eq!(res.len(), 0);
-
-        let query = QueryNode::Lookup(LookupLhs::Parameter("disease"), "YF");
-        let res = eval_query(&index, query).unwrap();
-        assert_eq!(res.len(), 2);
-
-        let query = QueryNode::Lookup(LookupLhs::Parameter("foo"), "bar");
         let res = eval_query(&index, query).unwrap();
         assert_eq!(res.len(), 0);
     }

--- a/src/query/query_parse.rs
+++ b/src/query/query_parse.rs
@@ -43,13 +43,9 @@ fn parse_query_content(query: pest::iterators::Pair<Rule>) -> Result<QueryNode, 
             let second_arg = infix.next().unwrap();
             match infix_function.as_str() {
                 "==" => {
-                    let lhs = get_first_inner_pair(first_arg);
-                    let lookup_type = match lhs.as_rule() {
-                        Rule::lookupId => LookupLhs::Id,
-                        Rule::lookupName => LookupLhs::Name,
-                        Rule::lookupParam => {
-                            LookupLhs::Parameter(get_first_inner_pair(lhs).as_str())
-                        }
+                    let lookup_type = match first_arg.as_str() {
+                        "id" => LookupLhs::Id,
+                        "name" => LookupLhs::Name,
                         _ => unreachable!(),
                     };
                     let search_term = get_string_inner(get_first_inner_pair(second_arg));
@@ -139,14 +135,6 @@ mod tests {
         assert!(matches!(res, QueryNode::Lookup(LookupLhs::Id, "12 3")));
         let res = parse_query("name == \"123\"").unwrap();
         assert!(matches!(res, QueryNode::Lookup(LookupLhs::Name, "123")));
-        let res = parse_query("parameter:x == \"foo\"").unwrap();
-        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x"), "foo")));
-        let res = parse_query("parameter:x==\"foo\"").unwrap();
-        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x"), "foo")));
-        let res = parse_query("parameter:longer==\"foo\"").unwrap();
-        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("longer"), "foo")));
-        let res = parse_query("parameter:x123==\"foo\"").unwrap();
-        assert!(matches!(res, QueryNode::Lookup(LookupLhs::Parameter("x123"), "foo")));
         let res = parse_query("latest(id == \"123\")").unwrap();
         match res {
             QueryNode::Latest(Some(value)) => {

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -1,12 +1,11 @@
 #[derive(Debug)]
-pub enum LookupLhs<'a> {
+pub enum LookupLhs {
     Name,
     Id,
-    Parameter(&'a str)
 }
 
 #[derive(Debug)]
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
-    Lookup(LookupLhs<'a>, &'a str),
+    Lookup(LookupLhs, &'a str),
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -113,7 +113,8 @@ fn can_list_metadata() {
 
     assert_eq!(entries[0].get("id").unwrap().as_str().unwrap(), "20170818-164830-33e0ab01");
     assert_eq!(entries[0].get("name").unwrap().as_str().unwrap(), "modup-201707-queries1");
-    assert_eq!(entries[0].get("parameters").unwrap().get("disease").unwrap(), "YF");
+    assert_eq!(entries[0].get("parameters").unwrap()
+                   .as_object().unwrap().get("disease").unwrap().as_str().unwrap(), "YF");
     assert_eq!(entries[0].get("custom").unwrap()
                    .as_object().unwrap().get("orderly").unwrap()
                    .as_object().unwrap().get("displayname").unwrap().as_str().unwrap(),

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -78,17 +78,3 @@ fn can_get_latest_of_lookup() {
         outpack::query::run_query(root_path, "latest(name == \"modup-201707-queries1\")").unwrap();
     assert_eq!(packets, "20180818-164043-7cdcde4b");
 }
-
-#[test]
-fn can_get_packet_by_parameter() {
-    let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "parameter:disease == \"YF\"").unwrap();
-    assert_eq!(packets, "20170818-164830-33e0ab01\n20180818-164043-7cdcde4b");
-    let packets =
-        outpack::query::run_query(root_path, "latest(parameter:disease == \"YF\")").unwrap();
-    assert_eq!(packets, "20180818-164043-7cdcde4b");
-    let packets =
-        outpack::query::run_query(root_path, "latest(parameter:unknown == \"YF\")").unwrap();
-    assert_eq!(packets, "Found no packets");
-}


### PR DESCRIPTION
Reverts mrc-ide/outpack_server#15

This is causing errors when we try to deserialise a packet with an integer parameter. So let's revert for now. We then need to iterate on this PR so that either it deserialises into the specific type (must support int, float, bool and string) or cast them all to string. If the later - check the behaviour in R querying. R can search for `parameter:x == 0.15` or `parameter:x == "0.15"` as equivalent. Does this work for boolean too?