### PR TITLE
Deserialize packet parameters and add helper function to test equality

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -18,7 +18,7 @@ mod tests {
     #[test]
     fn can_get_packet_index() {
         let index = get_packet_index("tests/example").unwrap();
-        assert_eq!(index.packets.len(), 3);
+        assert_eq!(index.packets.len(), 4);
         let ids: Vec<String> = index
             .packets
             .iter()
@@ -26,6 +26,7 @@ mod tests {
             .collect();
         assert_eq!(ids[0], "20170818-164830-33e0ab01");
         assert_eq!(ids[1], "20170818-164847-7574883b");
-        assert_eq!(ids[2], "20180818-164043-7cdcde4b");
+        assert_eq!(ids[2], "20180220-095832-16a4bbed");
+        assert_eq!(ids[3], "20180818-164043-7cdcde4b");
     }
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -78,6 +78,7 @@ mod tests {
         let entries = read_locations("tests/example").unwrap();
         assert_eq!(entries[0].packet, "20170818-164847-7574883b");
         assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");
-        assert_eq!(entries[2].packet, "20180818-164043-7cdcde4b");
+        assert_eq!(entries[2].packet, "20180220-095832-16a4bbed");
+        assert_eq!(entries[3].packet, "20180818-164043-7cdcde4b");
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -20,14 +20,16 @@ pub struct Packet {
     pub parameters: Option<HashMap<String, serde_json::Value>>,
 }
 
-pub enum ParameterValue {
+#[allow(dead_code)]
+pub enum ParameterValue<'a> {
     Bool(bool),
-    String(String),
+    String(&'a str),
     Integer(i32),
     Float(f64)
 }
 
 impl Packet {
+    #[allow(dead_code)]
     fn get_parameter(&self, param_name: &str) ->  Option<&serde_json::Value> {
         match &(self.parameters) {
             Some(params) => params.get(param_name),
@@ -35,6 +37,7 @@ impl Packet {
         }
     }
 
+    #[allow(dead_code)]
     fn parameter_equals(&self, param_name: &str, value: ParameterValue) -> bool {
         if let Some(json_value) = self.get_parameter(param_name) {
             match (json_value, value) {
@@ -337,12 +340,12 @@ mod tests {
         assert!(!packet.parameter_equals("tolerance",
                                          ParameterValue::Integer(10)));
         assert!(!packet.parameter_equals("tolerance",
-                                         ParameterValue::String(String::from("0.001"))));
+                                         ParameterValue::String("0.001")));
 
         assert!(packet.parameter_equals("disease",
-                                        ParameterValue::String(String::from("YF"))));
+                                        ParameterValue::String("YF")));
         assert!(!packet.parameter_equals("disease",
-                                        ParameterValue::String(String::from("HepB"))));
+                                        ParameterValue::String("HepB")));
         assert!(!packet.parameter_equals("disease",
                                         ParameterValue::Float(0.5)));
 
@@ -358,6 +361,6 @@ mod tests {
         assert!(!packet.parameter_equals("pull_data",
                                         ParameterValue::Bool(false)));
         assert!(!packet.parameter_equals("pull_data",
-                                         ParameterValue::String(String::from("true"))));
+                                         ParameterValue::String("true")));
     }
 }

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use std::{fs, io};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::str::{FromStr};
 use cached::cached_result;
@@ -17,7 +17,49 @@ pub struct Packet {
     pub id: String,
     pub name: String,
     pub custom: Option<serde_json::Value>,
-    pub parameters: Option<serde_json::Value>,
+    pub parameters: Option<HashMap<String, serde_json::Value>>,
+}
+
+pub enum ParameterValue {
+    Bool(bool),
+    String(String),
+    Integer(i32),
+    Float(f64)
+}
+
+impl Packet {
+    fn get_parameter(&self, param_name: &str) ->  Option<&serde_json::Value> {
+        match &(self.parameters) {
+            Some(params) => params.get(param_name),
+            None => None
+        }
+    }
+
+    fn parameter_equals(&self, param_name: &str, value: ParameterValue) -> bool {
+        if let Some(json_value) = self.get_parameter(param_name) {
+            match (json_value, value) {
+                (serde_json::value::Value::Bool(json_val), ParameterValue::Bool(test_val)) => {
+                    *json_val == test_val
+                },
+                (serde_json::value::Value::Number(json_val), ParameterValue::Float(test_val)) => {
+                    let test_number = serde_json::Number::from_f64(test_val);
+                    match test_number {
+                        Some(number) => *json_val == number,
+                        None => false,
+                    }
+                }
+                (serde_json::value::Value::Number(json_val), ParameterValue::Integer(test_val)) => {
+                    *json_val == serde_json::Number::from(test_val)
+                }
+                (serde_json::value::Value::String(json_val), ParameterValue::String(test_val)) => {
+                    *json_val == test_val
+                }
+                (_, _) => false,
+            }
+        } else {
+            false
+        }
+    }
 }
 
 cached_result! {
@@ -54,7 +96,7 @@ pub fn get_metadata_from_date(root_path: &str, from: Option<f64>) -> io::Result<
 
     let mut packets = match from {
         None => packets.map(|entry| read_entry(entry.path()))
-            .collect::<io::Result<Vec<Packet>>>()?,
+                .collect::<io::Result<Vec<Packet>>>()?,
         Some(time) => {
             let location_meta = read_locations(root_path)?;
             packets.filter(
@@ -147,7 +189,7 @@ mod tests {
     fn can_get_packets_from_date() {
         let all_packets = get_metadata_from_date("tests/example", None)
             .unwrap();
-        assert_eq!(all_packets.len(), 3);
+        assert_eq!(all_packets.len(), 4);
         let recent_packets = get_metadata_from_date("tests/example",
                                                     Some(1662480556 as f64))
             .unwrap();
@@ -157,7 +199,7 @@ mod tests {
         let recent_packets = get_metadata_from_date("tests/example",
                                                     Some(1662480555 as f64))
             .unwrap();
-        assert_eq!(recent_packets.len(), 3);
+        assert_eq!(recent_packets.len(), 4);
     }
 
     #[test]
@@ -173,14 +215,16 @@ mod tests {
                        String::from("20170819-164847-7574883b"),
                        String::from("20170819-164847-7574883a")];
         let id_string = get_sorted_id_string(ids);
-        assert_eq!(id_string, "20170818-164847-7574883b20170819-164847-7574883a20170819-164847-7574883b20180818-164847-7574883b")
+        assert_eq!(id_string, "20170818-164847-7574883b20170819-164847-7574883a\
+        20170819-164847-7574883b20180818-164847-7574883b")
     }
 
     #[test]
     fn can_get_ids_digest_with_config_alg() {
         let digest = get_ids_digest("tests/example", None)
             .unwrap();
-        let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180818-164043-7cdcde4b";
+        let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180220-095832-16a4bbed\
+        20180818-164043-7cdcde4b";
         let expected = format!("sha256:{:x}",
                                Sha256::new()
                                    .chain_update(dat)
@@ -192,7 +236,8 @@ mod tests {
     fn can_get_ids_digest_with_given_alg() {
         let digest = get_ids_digest("tests/example", Some(String::from("md5")))
             .unwrap();
-        let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180818-164043-7cdcde4b";
+        let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180220-095832-16a4bbed\
+        20180818-164043-7cdcde4b";
         let expected = format!("md5:{:x}",
                                md5::compute(dat));
         assert_eq!(digest, expected);
@@ -202,9 +247,10 @@ mod tests {
     fn can_get_ids() {
         let ids = get_ids("tests/example", None)
             .unwrap();
-        assert_eq!(ids.len(), 3);
+        assert_eq!(ids.len(), 4);
         assert!(ids.iter().any(|e| e == "20170818-164830-33e0ab01"));
         assert!(ids.iter().any(|e| e == "20170818-164847-7574883b"));
+        assert!(ids.iter().any(|e| e == "20180220-095832-16a4bbed"));
         assert!(ids.iter().any(|e| e == "20180818-164043-7cdcde4b"));
     }
 
@@ -254,5 +300,64 @@ mod tests {
                                        "20170818-164830-33e0ab0".to_string()],
                                   None).map_err(|e| e.kind());
         assert_eq!(Err(io::ErrorKind::InvalidInput), res);
+    }
+
+    #[test]
+    fn can_test_parameter_equality() {
+        let packets = get_metadata_from_date("tests/example", None)
+            .unwrap();
+        assert_eq!(packets.len(), 4);
+
+        let matching_packets: Vec<Packet> = packets
+            .into_iter()
+            .filter(|e| e.id == "20180220-095832-16a4bbed")
+            .collect();
+        assert_eq!(matching_packets.len(), 1);
+
+        let packet = matching_packets.first().unwrap();
+        assert_eq!(packet.id, "20180220-095832-16a4bbed");
+        assert_eq!(packet.name, "modup-201707-params1");
+        assert!(packet.parameters.is_some());
+
+        let params = packet.parameters.clone().unwrap();
+        assert_eq!(params.len(), 4);
+        assert_eq!(params.get("tolerance").unwrap(),
+                   &(serde_json::Value::Number(serde_json::Number::from_f64(0.001).unwrap())));
+        assert_eq!(params.get("size").unwrap(),
+                   &(serde_json::Value::Number(serde_json::Number::from(10))));
+        assert_eq!(params.get("disease").unwrap(),
+                   &(serde_json::Value::String(String::from("YF"))));
+        assert_eq!(params.get("pull_data").unwrap(),
+                   &(serde_json::Value::Bool(true)));
+
+        assert!(packet.parameter_equals("tolerance",
+                                        ParameterValue::Float(0.001)));
+        assert!(!packet.parameter_equals("tolerance",
+                                        ParameterValue::Float(0.002)));
+        assert!(!packet.parameter_equals("tolerance",
+                                         ParameterValue::Integer(10)));
+        assert!(!packet.parameter_equals("tolerance",
+                                         ParameterValue::String(String::from("0.001"))));
+
+        assert!(packet.parameter_equals("disease",
+                                        ParameterValue::String(String::from("YF"))));
+        assert!(!packet.parameter_equals("disease",
+                                        ParameterValue::String(String::from("HepB"))));
+        assert!(!packet.parameter_equals("disease",
+                                        ParameterValue::Float(0.5)));
+
+        assert!(packet.parameter_equals("size",
+                                        ParameterValue::Integer(10)));
+        assert!(!packet.parameter_equals("size",
+                                        ParameterValue::Integer(9)));
+        assert!(!packet.parameter_equals("size",
+                                         ParameterValue::Bool(true)));
+
+        assert!(packet.parameter_equals("pull_data",
+                                        ParameterValue::Bool(true)));
+        assert!(!packet.parameter_equals("pull_data",
+                                        ParameterValue::Bool(false)));
+        assert!(!packet.parameter_equals("pull_data",
+                                         ParameterValue::String(String::from("true"))));
     }
 }

--- a/src/query/query_format.rs
+++ b/src/query/query_format.rs
@@ -30,7 +30,7 @@ mod tests {
         let res = format_query_result(Ok(packet_refs)).unwrap();
         assert_eq!(
             res,
-            "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180818-164043-7cdcde4b"
+            "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180220-095832-16a4bbed\n20180818-164043-7cdcde4b"
         );
 
         let res = format_query_result(Ok(one_packet)).unwrap();

--- a/tests/example/.outpack/location/ae7a7bcb/20180220-095832-16a4bbed
+++ b/tests/example/.outpack/location/ae7a7bcb/20180220-095832-16a4bbed
@@ -1,0 +1,1 @@
+{"schema_version":"0.0.1","packet":"20180220-095832-16a4bbed","time":1662480555.6623,"hash":"sha256:ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73"}

--- a/tests/example/.outpack/metadata/20180220-095832-16a4bbed
+++ b/tests/example/.outpack/metadata/20180220-095832-16a4bbed
@@ -1,0 +1,540 @@
+{
+  "schema_version": "0.0.1",
+  "name": "modup-201707-params1",
+  "id": "20180220-095832-16a4bbed",
+  "time": {
+    "start": 1519120570.2232,
+    "end": 1519120712.2232
+  },
+  "parameters": {
+    "disease": "YF",
+    "pull_data": true,
+    "tolerance": 0.001,
+    "size": 10
+  },
+  "files": [
+    {
+      "path": "orderly.yml",
+      "size": 2348,
+      "hash": "sha256:8916131d0bebabc5ab098ae3a34b03389768e1ef15acba74ea265deddeba579f"
+    },
+    {
+      "path": "script.R",
+      "size": 48,
+      "hash": "sha256:d58d95afe19f8cd8835e29565717c9dfc7e472f1cfaaab38b7337f484c73752e"
+    },
+    {
+      "path": "report.Rmd",
+      "size": 21000,
+      "hash": "sha256:65d5abe20f567fdc29728bf71a911a06470321226c323f7028de2e698341ee07"
+    },
+    {
+      "path": "Q3.csv",
+      "size": 291,
+      "hash": "sha256:cd560478077e2c8a022c242bc982c5817d541c60148b41d901e21c2cb6300da1"
+    },
+    {
+      "path": "Q4.csv",
+      "size": 248,
+      "hash": "sha256:415a634775830ce31279810533c2e0e07766940a023a32a894a88a8507469f5b"
+    },
+    {
+      "path": "report.pdf",
+      "size": 155092,
+      "hash": "sha256:d573bfbb96f457ebd6d741570312d246c319e3edbf34380affdda378d060e060"
+    },
+    {
+      "path": "Figure1.pdf",
+      "size": 5750,
+      "hash": "sha256:328e31132d314ccfe0c56027f0d13bbb14dbc0aa298ddc8cd98e04aa6db8638d"
+    },
+    {
+      "path": "Figure2.pdf",
+      "size": 5647,
+      "hash": "sha256:02b8becbce68e8113bb3710a2474822d15c00e7ed9060ed94b10f0e137b2ee22"
+    },
+    {
+      "path": "Figure3.pdf",
+      "size": 15341,
+      "hash": "sha256:b742e3e1a60b4996e4bc2275e291617f06246f725ca5a2786e9526ebd62ab111"
+    },
+    {
+      "path": "Figure4.pdf",
+      "size": 5524,
+      "hash": "sha256:79cdfe6586a853ac3926e64780b31a0cfa8dbeba0af577aac8e157b180dc46b3"
+    },
+    {
+      "path": "Figure5.pdf",
+      "size": 11044,
+      "hash": "sha256:48c5d78f93970f704d952c93139a3d789e82b2e6b7967bc4118184ca66eff445"
+    },
+    {
+      "path": "Table1.csv",
+      "size": 594,
+      "hash": "sha256:cf3892002961a150b608538a078df040b6b2093df919878dd924948003744446"
+    },
+    {
+      "path": "Table2.csv",
+      "size": 568,
+      "hash": "sha256:3da62b06a9e201a3029943f7f76ec3aecc286dc278a7a38afbcf8c3e736ba4e0"
+    },
+    {
+      "path": "Table3.csv",
+      "size": 386,
+      "hash": "sha256:6ed3c64f01dc600b17465244c74020783ebc57613eee6c5e5d6695764e44272b"
+    },
+    {
+      "path": "Table4.csv",
+      "size": 551,
+      "hash": "sha256:f38c11bcd1e8772813531b9e7662127e0e7abd49282b8c1f505d39ae1c3e3cd3"
+    },
+    {
+      "path": "Table5.csv",
+      "size": 609,
+      "hash": "sha256:539b71e478d781740f59c7fb0605d995f6d94e9f2973760354cab962c261d739"
+    },
+    {
+      "path": "Table6.csv",
+      "size": 313,
+      "hash": "sha256:2af3032d53828bfc5b9726b5584cc610fd6e64b3ec76a3a69b9e764a63b21d0a"
+    },
+    {
+      "path": "Table7.csv",
+      "size": 606,
+      "hash": "sha256:c37d3a8b138b9daa055b4a3fc436aae662908625cb11e54b81ffebb828a6eedf"
+    },
+    {
+      "path": "Table8.csv",
+      "size": 300,
+      "hash": "sha256:6a54263e9e281cefbb4ad3cd8a17fb7fad2862492b01bc527987cb27d111b2f6"
+    },
+    {
+      "path": "all.rds",
+      "size": 4368694,
+      "hash": "sha256:1e1d762fc4a3bcd4e124e73a8e13e6514737b174ecfb3900e74458b6a3623e18"
+    },
+    {
+      "path": "summary.rds",
+      "size": 3564964,
+      "hash": "sha256:0eb70162748503aebbe1dbba6a55f88f117acc53610ad7e68bc7e003b7b97a0d"
+    }
+  ],
+  "depends": [
+    {
+      "packet": "20170818-164043-7cdcde4b",
+      "files": [
+        {
+          "here": "all.rds",
+          "there": "modified_update_201707.rds"
+        },
+        {
+          "here": "summary.rds",
+          "there": "modified_update_201707_summary.rds"
+        }
+      ]
+    }
+  ],
+  "script": [
+    "script.R"
+  ],
+  "session": {
+    "platform": {
+      "version": "R version 3.4.0 (2017-04-21)",
+      "os": "Debian GNU/Linux 9 (stretch)",
+      "system": "x86_64, linux-gnu"
+    },
+    "packages": [
+      {
+        "package": "kableExtra",
+        "version": "0.4.0",
+        "attached": true
+      },
+      {
+        "package": "knitr",
+        "version": "1.17",
+        "attached": true
+      },
+      {
+        "package": "RColorBrewer",
+        "version": "1.1-2",
+        "attached": true
+      },
+      {
+        "package": "gridExtra",
+        "version": "2.2.1",
+        "attached": true
+      },
+      {
+        "package": "ggplot2",
+        "version": "2.2.1",
+        "attached": true
+      },
+      {
+        "package": "Rcpp",
+        "version": "0.12.12",
+        "attached": false
+      },
+      {
+        "package": "highr",
+        "version": "0.6",
+        "attached": false
+      },
+      {
+        "package": "compiler",
+        "version": "3.4.0",
+        "attached": false
+      },
+      {
+        "package": "plyr",
+        "version": "1.8.4",
+        "attached": false
+      },
+      {
+        "package": "methods",
+        "version": "3.4.0",
+        "attached": false
+      },
+      {
+        "package": "RPostgres",
+        "version": "0.1-4",
+        "attached": false
+      },
+      {
+        "package": "tools",
+        "version": "3.4.0",
+        "attached": false
+      },
+      {
+        "package": "digest",
+        "version": "0.6.12",
+        "attached": false
+      },
+      {
+        "package": "uuid",
+        "version": "0.1-2",
+        "attached": false
+      },
+      {
+        "package": "bit",
+        "version": "1.1-12",
+        "attached": false
+      },
+      {
+        "package": "RSQLite",
+        "version": "2.0",
+        "attached": false
+      },
+      {
+        "package": "memoise",
+        "version": "1.1.0",
+        "attached": false
+      },
+      {
+        "package": "evaluate",
+        "version": "0.10.1",
+        "attached": false
+      },
+      {
+        "package": "tibble",
+        "version": "1.3.3",
+        "attached": false
+      },
+      {
+        "package": "gtable",
+        "version": "0.2.0",
+        "attached": false
+      },
+      {
+        "package": "pkgconfig",
+        "version": "2.0.1",
+        "attached": false
+      },
+      {
+        "package": "rlang",
+        "version": "0.1.2",
+        "attached": false
+      },
+      {
+        "package": "DBI",
+        "version": "0.7",
+        "attached": false
+      },
+      {
+        "package": "yaml",
+        "version": "2.1.14",
+        "attached": false
+      },
+      {
+        "package": "xml2",
+        "version": "1.1.1",
+        "attached": false
+      },
+      {
+        "package": "httr",
+        "version": "1.3.0",
+        "attached": false
+      },
+      {
+        "package": "stringr",
+        "version": "1.2.0",
+        "attached": false
+      },
+      {
+        "package": "withr",
+        "version": "2.0.0",
+        "attached": false
+      },
+      {
+        "package": "hms",
+        "version": "0.3",
+        "attached": false
+      },
+      {
+        "package": "bit64",
+        "version": "0.9-7",
+        "attached": false
+      },
+      {
+        "package": "rprojroot",
+        "version": "1.2",
+        "attached": false
+      },
+      {
+        "package": "grid",
+        "version": "3.4.0",
+        "attached": false
+      },
+      {
+        "package": "getopt",
+        "version": "1.20.0",
+        "attached": false
+      },
+      {
+        "package": "optparse",
+        "version": "1.4.4",
+        "attached": false
+      },
+      {
+        "package": "R6",
+        "version": "2.2.2",
+        "attached": false
+      },
+      {
+        "package": "orderly",
+        "version": "0.1.0",
+        "attached": false
+      },
+      {
+        "package": "rmarkdown",
+        "version": "1.6",
+        "attached": false
+      },
+      {
+        "package": "reshape2",
+        "version": "1.4.2",
+        "attached": false
+      },
+      {
+        "package": "readr",
+        "version": "1.1.1",
+        "attached": false
+      },
+      {
+        "package": "blob",
+        "version": "1.1.0",
+        "attached": false
+      },
+      {
+        "package": "magrittr",
+        "version": "1.5",
+        "attached": false
+      },
+      {
+        "package": "ids",
+        "version": "1.0.1",
+        "attached": false
+      },
+      {
+        "package": "scales",
+        "version": "0.4.1",
+        "attached": false
+      },
+      {
+        "package": "backports",
+        "version": "1.1.0",
+        "attached": false
+      },
+      {
+        "package": "htmltools",
+        "version": "0.3.6",
+        "attached": false
+      },
+      {
+        "package": "rvest",
+        "version": "0.3.2",
+        "attached": false
+      },
+      {
+        "package": "colorspace",
+        "version": "1.3-2",
+        "attached": false
+      },
+      {
+        "package": "labeling",
+        "version": "0.3",
+        "attached": false
+      },
+      {
+        "package": "stringi",
+        "version": "1.1.5",
+        "attached": false
+      },
+      {
+        "package": "openssl",
+        "version": "0.9.6",
+        "attached": false
+      },
+      {
+        "package": "lazyeval",
+        "version": "0.2.0",
+        "attached": false
+      },
+      {
+        "package": "munsell",
+        "version": "0.4.3",
+        "attached": false
+      }
+    ]
+  },
+  "custom": {
+    "orderly": {
+      "artefacts": [
+        {
+          "description": "Summary of queries",
+          "paths": [
+            "report.pdf"
+          ]
+        },
+        {
+          "description": "Deaths Averted by antigen  period 2011-2016",
+          "paths": [
+            "Figure1.pdf"
+          ]
+        },
+        {
+          "description": "Comparison of Deaths Averted from WUENIC data 2016 and 2017 period 2011-2016",
+          "paths": [
+            "Figure2.pdf"
+          ]
+        },
+        {
+          "description": "Projected Coverage for routine immunisation in PINE countries",
+          "paths": [
+            "Figure3.pdf"
+          ]
+        },
+        {
+          "description": "Comparison of projected and actual impact estimates in PINE countries",
+          "paths": [
+            "Figure4.pdf"
+          ]
+        },
+        {
+          "description": "Estimated Actual Coverage for routine immunisation in PINE countries",
+          "paths": [
+            "Figure5.pdf"
+          ]
+        },
+        {
+          "description": "Deaths averted (thousands) in 2016",
+          "paths": [
+            "Table1.csv"
+          ]
+        },
+        {
+          "description": "Deaths averted (millions) in the period 2011-2016",
+          "paths": [
+            "Table2.csv"
+          ]
+        },
+        {
+          "description": "Wuenic coverage for the year 2015, as estimated in 2016 vs 2017, for a few large countries",
+          "paths": [
+            "Table3.csv"
+          ]
+        },
+        {
+          "description": "Comparison of the total impact from WUENIC coverage data 2016 vs 2017 (as thousand deaths averted) year 2015",
+          "paths": [
+            "Table4.csv"
+          ]
+        },
+        {
+          "description": "Comparison of the impact from WUENIC coverage data 2016 vs 2017 (as million deaths averted) years 2011-2016",
+          "paths": [
+            "Table5.csv"
+          ]
+        },
+        {
+          "description": "DHS vs WUENIC coverage for Ethiopia in 2016",
+          "paths": [
+            "Table6.csv"
+          ]
+        },
+        {
+          "description": "Comparison of the global impact of DHS vs WUENIC coverage for 2016 as deaths averted (thousands)",
+          "paths": [
+            "Table7.csv"
+          ]
+        },
+        {
+          "description": "Comparison of the impact of DHS vs WUENIC coverage for Ethiopia in 2016 as deaths averted (thousands)",
+          "paths": [
+            "Table8.csv"
+          ]
+        }
+      ],
+      "packages": [
+        "ggplot2",
+        "gridExtra",
+        "RColorBrewer",
+        "knitr",
+        "kableExtra"
+      ],
+      "global": [],
+      "role": [
+        {
+          "path": "orderly.yml",
+          "role": "orderly_yml"
+        },
+        {
+          "path": "script.R",
+          "role": "script"
+        },
+        {
+          "path": "report.Rmd",
+          "role": "resource"
+        },
+        {
+          "path": "Q3.csv",
+          "role": "resource"
+        },
+        {
+          "path": "Q4.csv",
+          "role": "resource"
+        },
+        {
+          "path": "all.rds",
+          "role": "dependency"
+        },
+        {
+          "path": "summary.rds",
+          "role": "dependency"
+        }
+      ],
+      "displayname": "Modified Update",
+      "description": "First round of queries from BMGF regarding the July 2017 modified update",
+      "custom": null
+    }
+  }
+}

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -72,7 +72,7 @@ fn can_list_location_metadata() {
     validate_success("location.json", &body);
 
     let entries = body.get("data").unwrap().as_array().unwrap();
-    assert_eq!(entries.len(), 3);
+    assert_eq!(entries.len(), 4);
 
     assert_eq!(entries[0].get("packet").unwrap().as_str().unwrap(), "20170818-164847-7574883b");
     assert_eq!(entries[0].get("time").unwrap().as_f64().unwrap(), 1662480556.1778);
@@ -80,7 +80,8 @@ fn can_list_location_metadata() {
                "sha256:af3c863f96898c6c88cee4daa1a6d6cfb756025e70059f5ea4dbe4d9cc5e0e36");
 
     assert_eq!(entries[1].get("packet").unwrap().as_str().unwrap(), "20170818-164830-33e0ab01");
-    assert_eq!(entries[2].get("packet").unwrap().as_str().unwrap(), "20180818-164043-7cdcde4b");
+    assert_eq!(entries[2].get("packet").unwrap().as_str().unwrap(), "20180220-095832-16a4bbed");
+    assert_eq!(entries[3].get("packet").unwrap().as_str().unwrap(), "20180818-164043-7cdcde4b");
 }
 
 #[test]
@@ -109,7 +110,7 @@ fn can_list_metadata() {
     validate_success("list.json", &body);
 
     let entries = body.get("data").unwrap().as_array().unwrap();
-    assert_eq!(entries.len(), 3);
+    assert_eq!(entries.len(), 4);
 
     assert_eq!(entries[0].get("id").unwrap().as_str().unwrap(), "20170818-164830-33e0ab01");
     assert_eq!(entries[0].get("name").unwrap().as_str().unwrap(), "modup-201707-queries1");
@@ -121,7 +122,8 @@ fn can_list_metadata() {
                "Modified Update");
 
     assert_eq!(entries[1].get("id").unwrap().as_str().unwrap(), "20170818-164847-7574883b");
-    assert_eq!(entries[2].get("id").unwrap().as_str().unwrap(), "20180818-164043-7cdcde4b");
+    assert_eq!(entries[2].get("id").unwrap().as_str().unwrap(), "20180220-095832-16a4bbed");
+    assert_eq!(entries[3].get("id").unwrap().as_str().unwrap(), "20180818-164043-7cdcde4b");
 }
 
 #[test]


### PR DESCRIPTION
This PR will
* Add a new packet into the example which has 4 parameters, 1 float, 1 int, 1 string and 1 bool
* Will deserailise these into an `Option<HashMap<String, serde_json::Value>>`
* Add a method `parameter_equals` which can be used for testing if a `Packet` has a parameter with a certain value (see #21 for an example of how I want to use this)

I want to use this to fix up #15 which we had to revert because the changes I made there were causing issues with deserialisation. See #18 