### PR TITLE
Remove the unpacked directory

### DIFF
--- a/buildkite/docker
+++ b/buildkite/docker
@@ -4,7 +4,7 @@ set -e
 HERE=$(dirname "$0")
 . "$HERE"/common
 
-docker build -t "$COMMIT_TAG" "$HERE"/../
+docker build --pull -t "$COMMIT_TAG" "$HERE"/../
 
 docker push "$COMMIT_TAG"
 docker tag "$COMMIT_TAG" "$BRANCH_TAG"

--- a/src/location.rs
+++ b/src/location.rs
@@ -70,7 +70,7 @@ pub fn read_locations(root_path: &str) -> io::Result<Vec<LocationEntry>> {
     Ok(packets)
 }
 
-pub fn get_local_location_id(root_path: &str) -> Result<String, Error> {
+pub fn get_local_location_id(root_path: &str) -> io::Result<String> {
     let location = config::read_config(root_path)?
         .location
         .iter()

--- a/src/location.rs
+++ b/src/location.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::{fs, io};
 use std::ffi::{OsString};
 use std::fs::{DirEntry};
+use std::io::{Error};
 use std::path::{Path, PathBuf};
 use cached::cached_result;
 use crate::config::Location;
@@ -69,6 +70,17 @@ pub fn read_locations(root_path: &str) -> io::Result<Vec<LocationEntry>> {
     Ok(packets)
 }
 
+pub fn get_local_location_id(root_path: &str) -> Result<String, Error> {
+    let location = config::read_config(root_path)?
+        .location
+        .iter()
+        .filter(|loc| loc.name == "local")
+        .next()
+        .unwrap()
+        .id.clone();
+    Ok(location)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,5 +91,10 @@ mod tests {
         assert_eq!(entries[0].packet, "20170818-164847-7574883b");
         assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");
         assert_eq!(entries[2].packet, "20180818-164043-7cdcde4b");
+    }
+
+    #[test]
+    fn can_find_local_id() {
+        assert_eq!(get_local_location_id("tests/example").unwrap(), "be7a7bcb");
     }
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -2,7 +2,6 @@ use serde::{Deserialize, Serialize};
 use std::{fs, io};
 use std::ffi::{OsString};
 use std::fs::{DirEntry};
-use std::io::{Error};
 use std::path::{Path, PathBuf};
 use cached::cached_result;
 use crate::config::Location;

--- a/src/location.rs
+++ b/src/location.rs
@@ -74,9 +74,8 @@ pub fn get_local_location_id(root_path: &str) -> Result<String, Error> {
     let location = config::read_config(root_path)?
         .location
         .iter()
-        .filter(|loc| loc.name == "local")
-        .next()
-        .unwrap()
+        .find(|loc| loc.name == "local")
+        .unwrap() // every outpack configuration must have this.
         .id.clone();
     Ok(location)
 }

--- a/tests/example/.outpack/unpacked/20170818-164830-33e0ab01
+++ b/tests/example/.outpack/unpacked/20170818-164830-33e0ab01
@@ -1,1 +1,0 @@
-{"schema_version":"0.0.1","packet":"20170818-164830-33e0ab01","time":1662480555.8897,"hash":"sha256:5380b3c9a1f93ab3aeaf1ed6367b98aba73dc6bfae3f68fe7d9fe05f57479cbf"}

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -297,8 +297,8 @@ fn can_get_missing_unpacked_ids() {
     let rocket = get_test_rocket();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.post("/packets/missing").json(&Ids {
-        ids: vec!["20180818-164043-7cdcde4b".to_string(),
-                  "20170818-164830-33e0ab01".to_string()],
+        ids: vec!["20170818-164847-7574883b".to_string(),
+                  "20170818-164830-33e0ab02".to_string()],
         unpacked: true,
     }).dispatch();
     assert_eq!(response.status(), Status::Ok);
@@ -308,7 +308,7 @@ fn can_get_missing_unpacked_ids() {
     validate_success("ids.json", &body);
     let entries = body.get("data").unwrap().as_array().unwrap();
     assert_eq!(entries.len(), 1);
-    assert_eq!(entries.first().unwrap().as_str(), Some("20180818-164043-7cdcde4b"));
+    assert_eq!(entries.first().unwrap().as_str(), Some("20170818-164830-33e0ab02"));
 }
 
 #[test]


### PR DESCRIPTION
This PR removes the `.outpack/unpacked` directory from the example, and updates the limited code that uses it to no longer need it.

See https://github.com/mrc-ide/outpack/pull/76 for context, this is where it was removed from outpack.