### PR TITLE
mrc-4310 POST metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,23 @@ The file contents should be written directly to the request body.
 }
 ```
 
+## POST /packet/<hash>
+Upload packet metadata with the given hash. Returns a 400 if the hash does not match the contents.
+This method is idempotent; if the file already exists it will not do anything.
+
+### Body
+The metadata should be written directly to the request body.
+
+### Response
+
+```
+{
+  "status": "success",
+  "errors": null,
+  "data": null
+}
+```
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/schema/list.json
+++ b/schema/list.json
@@ -24,6 +24,6 @@
             }
         },
         "required": ["id", "name"],
-        "additionalProperties": false
+        "additionalProperties": true
     }
 }

--- a/schema/list.json
+++ b/schema/list.json
@@ -24,6 +24,6 @@
             }
         },
         "required": ["id", "name"],
-        "additionalProperties": true
+        "additionalProperties": false
     }
 }

--- a/schema/location.json
+++ b/schema/location.json
@@ -12,9 +12,13 @@
       },
       "hash": {
         "$ref": "hash.json"
+      },
+      "schema_version": {
+        "type": "string",
+        "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
       }
     },
-    "required": ["packet", "time", "hash"],
+    "required": ["packet", "time", "hash", "schema_version"],
     "additionalProperties": false
   }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -108,6 +108,17 @@ async fn add_file(
         .map(OutpackSuccess::from)
 }
 
+#[rocket::post("/packet/<hash>", format = "plain", data = "<packet>")]
+async fn add_packet(
+    root: &State<String>,
+    hash: String,
+    packet: String,
+) -> Result<OutpackSuccess<()>, OutpackError> {
+    metadata::add_metadata(root, &packet, &hash)
+        .map_err(OutpackError::from)
+        .map(OutpackSuccess::from)
+}
+
 #[derive(Serialize, Deserialize)]
 #[serde(crate = "rocket::serde")]
 struct Ids {
@@ -127,5 +138,5 @@ pub fn api(root: String) -> Rocket<Build> {
         .register("/", catchers![internal_error, not_found])
         .mount("/", routes![index, list_location_metadata, get_metadata,
             get_metadata_by_id, get_metadata_raw, get_file, get_checksum, get_missing_packets,
-            get_missing_files, add_file])
+            get_missing_files, add_file, add_packet])
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -50,8 +50,8 @@ fn list_location_metadata(root: &State<String>) -> OutpackResult<Vec<location::L
 }
 
 #[rocket::get("/packit/metadata?<known_since>")]
-fn get_metadata(root: &State<String>, known_since: Option<f64>) -> OutpackResult<Vec<metadata::Packet>> {
-    metadata::get_metadata_from_date(root, known_since)
+fn get_metadata(root: &State<String>, known_since: Option<f64>) -> OutpackResult<Vec<metadata::PackitPacket>> {
+    metadata::get_packit_metadata_from_date(root, known_since)
         .map_err(OutpackError::from)
         .map(OutpackSuccess::from)
 }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -31,7 +31,7 @@ pub fn hash_parse(hash: &str) -> io::Result<ParsedHash> {
     Ok(ParsedHash { algorithm, value })
 }
 
-pub fn hash_data(data: String, algorithm: HashAlgorithm) -> String {
+pub fn hash_data(data: &str, algorithm: HashAlgorithm) -> String {
     match algorithm {
         HashAlgorithm::md5 => format!("md5:{:x}", md5::compute(data)),
         HashAlgorithm::sha1 => format!("sha1:{:x}", Sha1::new()
@@ -63,7 +63,7 @@ mod tests {
 
     #[test]
     fn can_hash_data() {
-        let data = String::from("1234");
+        let data = "1234";
         let expected = format!("{:x}", md5::compute(&data));
         let res = hash_parse(&hash_data(data, HashAlgorithm::md5)).unwrap();
         assert_eq!(res.algorithm, "md5");

--- a/src/location.rs
+++ b/src/location.rs
@@ -3,15 +3,15 @@ use std::{fs, io};
 use std::ffi::{OsString};
 use std::fs::{DirEntry};
 use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
 use cached::cached_result;
 use cached::instant::SystemTime;
 use crate::config::Location;
+use crate::utils::time_as_num;
 
 use super::config;
 use super::utils;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct LocationEntry {
     pub packet: String,
     pub time: f64,
@@ -86,7 +86,7 @@ pub fn mark_packet_known(packet_id: &str, location_id: &str, hash: &str, time: S
     let schema_version = config::read_config(root)?.schema_version;
     let entry = LocationEntry {
         packet: String::from(packet_id),
-        time: time.duration_since(UNIX_EPOCH).unwrap().as_millis() as f64,
+        time: time_as_num(time),
         hash: String::from(hash),
         schema_version,
     };
@@ -98,14 +98,18 @@ pub fn mark_packet_known(packet_id: &str, location_id: &str, hash: &str, time: S
 
     fs::create_dir_all(&location_path)?;
     let path = location_path.join(packet_id);
-    fs::File::create(&path)?;
-    let json = serde_json::to_string(&entry)?;
-    fs::write(path, json)?;
+    if !path.exists() {
+        fs::File::create(&path)?;
+        let json = serde_json::to_string(&entry)?;
+        fs::write(path, json)?;
+    }
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, SystemTime};
+    use crate::test_utils::tests::get_temp_outpack_root;
     use super::*;
 
     #[test]
@@ -114,5 +118,49 @@ mod tests {
         assert_eq!(entries[0].packet, "20170818-164847-7574883b");
         assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");
         assert_eq!(entries[2].packet, "20180818-164043-7cdcde4b");
+    }
+
+    #[test]
+    fn can_mark_known() {
+        let root = get_temp_outpack_root();
+        let loc_a = Path::new(root.as_path()).join(".outpack/location/ae7a7bcb");
+        let entries_a = read_location(loc_a).unwrap();
+        let entry_a = entries_a.first().unwrap();
+        let loc_b = Path::new(root.as_path()).join(".outpack/location/be7a7bcb");
+        let entries_b = read_location(loc_b.clone()).unwrap();
+        assert!(entries_b.iter().find(|e| e.packet == entry_a.packet).is_none());
+        let now = SystemTime::now();
+        mark_packet_known(&entry_a.packet, "be7a7bcb", &entry_a.hash,
+                          SystemTime::now(), root.as_path().to_str().unwrap()).unwrap();
+        let entries_b = read_location(loc_b).unwrap();
+        let res = entries_b.iter().find(|e| e.packet == entry_a.packet).unwrap();
+        assert_eq!(res.time, time_as_num(now));
+        assert_eq!(res.packet, entry_a.packet);
+        assert_eq!(res.hash, entry_a.hash);
+        assert_eq!(res.schema_version, entry_a.schema_version);
+    }
+
+    #[test]
+    fn marking_known_does_not_overwrite() {
+        let root = get_temp_outpack_root();
+        let loc_a = Path::new(root.as_path()).join(".outpack/location/ae7a7bcb");
+        let entries_a = read_location(loc_a).unwrap();
+        let entry_a = entries_a.first().unwrap();
+        let now = SystemTime::now();
+        mark_packet_known(&entry_a.packet, "be7a7bcb", &entry_a.hash,
+                          SystemTime::now(), root.as_path().to_str().unwrap()).unwrap();
+
+        let loc_b = Path::new(root.as_path()).join(".outpack/location/be7a7bcb");
+        let entries_b = read_location(loc_b.clone()).unwrap();
+        let res = entries_b.iter().find(|e| e.packet == entry_a.packet).unwrap();
+        assert_eq!(res.time, time_as_num(now));
+
+        mark_packet_known(&entry_a.packet, "be7a7bcb", &entry_a.hash,
+                          SystemTime::now() + Duration::from_secs(120), root.as_path().to_str().unwrap()).unwrap();
+
+        let entries_b = read_location(loc_b).unwrap();
+        let res = entries_b.iter().find(|e| e.packet == entry_a.packet).unwrap();
+        // time known should still be the time it was first added at
+        assert_eq!(res.time, time_as_num(now));
     }
 }

--- a/src/location.rs
+++ b/src/location.rs
@@ -3,7 +3,9 @@ use std::{fs, io};
 use std::ffi::{OsString};
 use std::fs::{DirEntry};
 use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 use cached::cached_result;
+use cached::instant::SystemTime;
 use crate::config::Location;
 
 use super::config;
@@ -14,6 +16,7 @@ pub struct LocationEntry {
     pub packet: String,
     pub time: f64,
     pub hash: String,
+    pub schema_version: String,
 }
 
 cached_result! {
@@ -67,6 +70,33 @@ pub fn read_locations(root_path: &str) -> io::Result<Vec<LocationEntry>> {
         .collect();
 
     Ok(packets)
+}
+
+pub fn get_local_location_id(root: &str) -> io::Result<String> {
+    let config = config::read_config(root)?;
+    Ok(config.location.iter().find(|l| l.name == "local")
+        .ok_or(io::Error::new(io::ErrorKind::InvalidData, "No local location"))?.id.clone())
+}
+
+pub fn mark_packet_known(packet_id: &str, location_id: &str, hash: &str, time: SystemTime, root: &str) -> io::Result<()> {
+    let schema_version = config::read_config(root)?.schema_version;
+    let entry = LocationEntry {
+        packet: String::from(packet_id),
+        time: time.duration_since(UNIX_EPOCH).unwrap().as_millis() as f64,
+        hash: String::from(hash),
+        schema_version,
+    };
+
+    let path = Path::new(root)
+        .join(".outpack")
+        .join("location")
+        .join(location_id)
+        .join(packet_id);
+
+    fs::File::create(&path)?;
+    let json = serde_json::to_string(&entry)?;
+    fs::write(path, json)?;
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,6 +17,25 @@ use super::hash;
 use super::utils;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PackitPacket {
+    pub id: String,
+    pub name: String,
+    pub custom: Option<serde_json::Value>,
+    pub parameters: Option<HashMap<String, serde_json::Value>>,
+}
+
+impl PackitPacket {
+    fn from(packet: &Packet) -> PackitPacket {
+        PackitPacket {
+            id: packet.id.to_string(),
+            name: packet.name.to_string(),
+            custom: packet.custom.clone(),
+            parameters: packet.parameters.clone(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Packet {
     pub id: String,
     pub name: String,
@@ -114,6 +133,11 @@ fn get_metadata_file(root_path: &str, id: &str) -> io::Result<PathBuf> {
     } else {
         Ok(path)
     }
+}
+
+pub fn get_packit_metadata_from_date(root_path: &str, from: Option<f64>) -> io::Result<Vec<PackitPacket>> {
+    let packets = get_metadata_from_date(root_path, from)?;
+    Ok(packets.iter().map(PackitPacket::from).collect())
 }
 
 pub fn get_metadata_from_date(root_path: &str, from: Option<f64>) -> io::Result<Vec<Packet>> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -413,29 +413,29 @@ mod tests {
 
     #[test]
     fn can_add_metadata() {
-        let data = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+        let data = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [
+                              "parameters": null,
+                              "files": [
                                {
-                                  \"path\": \"data.csv\",
-                                  \"size\": 51,
-                                  \"hash\": \"sha256:b189579a9326f585d308304bd9e03326be5d395ac71b31df359ab8bac408d248\"
+                                  "path": "data.csv",
+                                  "size": 51,
+                                  "hash": "sha256:b189579a9326f585d308304bd9e03326be5d395ac71b31df359ab8bac408d248"
                                 }],
-                              \"depends\": [{
-                                  \"packet\": \"20170818-164847-7574883b\",
-                                  \"files\": []
+                              "depends": [{
+                                  "packet": "20170818-164847-7574883b",
+                                  "files": []
                               }],
-                              \"script\": [
-                                \"orderly.R\"
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
         let hash = hash::hash_data(data, HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
@@ -447,21 +447,21 @@ mod tests {
 
     #[test]
     fn add_metadata_is_idempotent() {
-        let data = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+        let data = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [],
-                              \"depends\": [],
-                              \"script\": [
-                                \"orderly.R\"
+                              "parameters": null,
+                              "files": [],
+                              "depends": [],
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
         let hash = hash::hash_data(data, HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
@@ -474,21 +474,21 @@ mod tests {
 
     #[test]
     fn imported_metadata_is_added_to_local_location() {
-        let data = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+        let data = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [],
-                              \"depends\": [],
-                              \"script\": [
-                                \"orderly.R\"
+                              "parameters": null,
+                              "files": [],
+                              "depends": [],
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
         let hash = hash::hash_data(data, HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
@@ -512,27 +512,27 @@ mod tests {
 
     #[test]
     fn cannot_put_metadata_with_missing_files() {
-        let data = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+        let data = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [
+                              "parameters": null,
+                              "files": [
                                 {
-                                  \"path\": \"data.csv\",
-                                  \"size\": 51,
-                                  \"hash\": \"sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164\"
+                                  "path": "data.csv",
+                                  "size": 51,
+                                  "hash": "sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164"
                                 }
                               ],
-                              \"depends\": [],
-                              \"script\": [
-                                \"orderly.R\"
+                              "depends": [],
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
         let hash = hash::hash_data(data, HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
@@ -543,24 +543,24 @@ mod tests {
 
     #[test]
     fn cannot_put_metadata_with_missing_dependencies() {
-        let data = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+        let data = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [],
-                              \"depends\": [{
-                                \"packet\": \"20230427-150828-68772cea\",
-                                \"files\": []
+                              "parameters": null,
+                              "files": [],
+                              "depends": [{
+                                "packet": "20230427-150828-68772cea",
+                                "files": []
                               }],
-                              \"script\": [
-                                \"orderly.R\"
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
         let hash = hash::hash_data(data, HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();

--- a/src/store.rs
+++ b/src/store.rs
@@ -38,7 +38,7 @@ pub async fn put_file(root: &str, mut file: TempFile<'_>, hash: &str) -> io::Res
     file.persist_to(&temp_path).await?;
     let alg = config::read_config(root)?.core.hash_algorithm;
     let content = fs::read_to_string(&temp_path)?;
-    let valid_hash = hash::hash_data(content, alg);
+    let valid_hash = hash::hash_data(&content, alg);
     if hash != valid_hash {
         return Err(io::Error::new(ErrorKind::InvalidInput,
                                   format!("Hash {} does not match file contents. Expected {}",
@@ -88,7 +88,7 @@ mod tests {
         let mut temp_file = TempFile::Buffered {
             content: data
         };
-        let hash = hash_data(String::from(data), HashAlgorithm::sha256);
+        let hash = hash_data(data, HashAlgorithm::sha256);
         temp_file.persist_to(root.path().join(&hash)).await.unwrap();
         let root_path = root.path();
         let outpack_path = root_path.join(".outpack");
@@ -127,6 +127,6 @@ mod tests {
         let res = put_file(root_str, temp_file, "badhash").await;
         assert_eq!(res.unwrap_err().to_string(),
                    format!("Hash badhash does not match file contents. Expected {}",
-                           hash_data(String::from(data), HashAlgorithm::sha256)));
+                           hash_data(data, HashAlgorithm::sha256)));
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -49,9 +49,9 @@ pub async fn put_file(root: &str, mut file: TempFile<'_>, hash: &str) -> io::Res
 
 #[cfg(test)]
 mod tests {
-    use tempfile::tempdir;
     use crate::config::HashAlgorithm;
     use crate::hash::hash_data;
+    use crate::test_utils::tests::get_temp_outpack_root;
     use super::*;
 
     #[test]
@@ -71,19 +71,15 @@ mod tests {
 
     #[rocket::async_test]
     async fn put_file_is_idempotent() {
-        let root = tempdir().unwrap();
+        let root = get_temp_outpack_root();
         let data = "Testing 123.";
         let mut temp_file = TempFile::Buffered {
             content: data
         };
         let hash = hash_data(data, HashAlgorithm::sha256);
-        temp_file.persist_to(root.path().join(&hash)).await.unwrap();
-        let root_path = root.path();
-        let outpack_path = root_path.join(".outpack");
-        fs::create_dir(&outpack_path).unwrap();
-        fs::copy("tests/example/.outpack/config.json", outpack_path.join("config.json")).unwrap();
+        temp_file.persist_to(root.join(&hash)).await.unwrap();
 
-        let root_str = root_path.to_str().unwrap();
+        let root_str = root.to_str().unwrap();
         let res = put_file(root_str, temp_file, &hash).await;
         let expected = file_path(root_str, &hash).unwrap();
         let expected = expected.to_str().unwrap();
@@ -93,26 +89,21 @@ mod tests {
         let mut temp_file = TempFile::Buffered {
             content: data
         };
-        temp_file.persist_to(root.path().join(&hash)).await.unwrap();
+        temp_file.persist_to(root.join(&hash)).await.unwrap();
         let res = put_file(root_str, temp_file, &hash).await;
         assert!(res.is_ok());
     }
 
     #[rocket::async_test]
     async fn put_file_validates_hash() {
-        let root = tempdir().unwrap();
+        let root = get_temp_outpack_root();
         let data = "Testing 123.";
         let mut temp_file = TempFile::Buffered {
             content: data
         };
-        temp_file.persist_to(root.path().join("badhash")).await.unwrap();
-        let root_path = root.path();
-        let outpack_path = root_path.join(".outpack");
-        fs::create_dir(&outpack_path).unwrap();
-        fs::copy("tests/example/.outpack/config.json", outpack_path.join("config.json")).unwrap();
-
-        let root_str = root_path.to_str().unwrap();
-        let res = put_file(root_str, temp_file, "badhash").await;
+        temp_file.persist_to(root.join("badhash")).await.unwrap();
+        let root_path = root.to_str().unwrap();
+        let res = put_file(root_path, temp_file, "badhash").await;
         assert_eq!(res.unwrap_err().to_string(),
                    format!("invalid hash 'badhash'"));
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,15 +2,20 @@
 pub mod tests {
     use crate::metadata::Packet;
     use std::collections::HashMap;
+    use std::fs::File;
     use std::hash::Hash;
+    use std::path::{Path, PathBuf};
+    use std::sync::Once;
+    use tar::{Archive, Builder};
+    use tempdir;
 
     pub fn vector_equals<T>(a: &[T], b: &[T]) -> bool
-    where
-        T: Eq + Hash,
-    {
-        fn count<T>(items: &[T]) -> HashMap<&T, usize>
         where
             T: Eq + Hash,
+    {
+        fn count<T>(items: &[T]) -> HashMap<&T, usize>
+            where
+                T: Eq + Hash,
         {
             let mut cnt = HashMap::new();
             for i in items {
@@ -31,4 +36,24 @@ pub mod tests {
             ids
         )
     }
+
+    static INIT: Once = Once::new();
+
+    pub fn initialize() {
+        INIT.call_once(|| {
+            let mut ar = Builder::new(File::create("example.tar")
+                .expect("File created"));
+            ar.append_dir_all("example", "tests/example").unwrap();
+            ar.finish().unwrap();
+        });
+    }
+
+    pub fn get_temp_outpack_root() -> PathBuf {
+        initialize();
+        let tmp_dir = tempdir::TempDir::new("outpack").expect("Temp dir created");
+        let mut ar = Archive::new(File::open("example.tar").unwrap());
+        ar.unpack(&tmp_dir).expect("unwrapped");
+        Path::new(&tmp_dir.into_path()).join("example")
+    }
+
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,6 @@
 use std::ffi::{OsString};
+use std::time::UNIX_EPOCH;
+use cached::instant::SystemTime;
 use lazy_static::lazy_static;
 use regex::Regex;
 
@@ -15,8 +17,13 @@ pub fn is_packet_str(name: &str) -> bool {
     ID_REG.is_match(name)
 }
 
+pub fn time_as_num(time: SystemTime) -> f64 {
+    (time.duration_since(UNIX_EPOCH).unwrap().as_millis() as f64) / 1000.0
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
     use super::*;
 
     #[test]
@@ -24,5 +31,13 @@ mod tests {
         assert_eq!(is_packet(&OsString::from("1234")), false);
         assert_eq!(is_packet(&OsString::from("20170818-164830-33e0ab01")), true);
         assert_eq!(is_packet(&OsString::from("20180818-164847-54699abf")), true)
+    }
+
+    #[test]
+    fn converts_time_to_seconds() {
+        let epoch_ms = 1688033668123;
+        let time = UNIX_EPOCH + Duration::from_millis(epoch_ms);
+        let res = time_as_num(time);
+        assert_eq!(res, 1688033668.123);
     }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -422,21 +422,21 @@ fn can_post_metadata() {
     let root = get_test_dir();
     let rocket = outpack::api::api(root.clone());
     let client = Client::tracked(rocket).expect("valid rocket instance");
-    let content = "{
-                             \"schema_version\": \"0.0.1\",
-                              \"name\": \"computed-resource\",
-                              \"id\": \"20230427-150828-68772cee\",
-                              \"time\": {
-                                \"start\": 1682608108.4139,
-                                \"end\": 1682608108.4309
+    let content = r#"{
+                             "schema_version": "0.0.1",
+                              "name": "computed-resource",
+                              "id": "20230427-150828-68772cee",
+                              "time": {
+                                "start": 1682608108.4139,
+                                "end": 1682608108.4309
                               },
-                              \"parameters\": null,
-                              \"files\": [],
-                              \"depends\": [],
-                              \"script\": [
-                                \"orderly.R\"
+                              "parameters": null,
+                              "files": [],
+                              "depends": [],
+                              "script": [
+                                "orderly.R"
                               ]
-                            }";
+                            }"#;
     let hash = format!("sha256:{:x}", Sha256::new()
         .chain_update(content)
         .finalize());

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -416,6 +416,50 @@ fn file_post_handles_errors() {
 }
 
 #[test]
+fn can_post_metadata() {
+    let root = get_test_dir();
+    let rocket = outpack::api::api(root.clone());
+    let client = Client::tracked(rocket).expect("valid rocket instance");
+    let content = "{
+                             \"schema_version\": \"0.0.1\",
+                              \"name\": \"computed-resource\",
+                              \"id\": \"20230427-150828-68772cee\",
+                              \"time\": {
+                                \"start\": 1682608108.4139,
+                                \"end\": 1682608108.4309
+                              },
+                              \"parameters\": null,
+                              \"files\": [],
+                              \"depends\": [],
+                              \"script\": [
+                                \"orderly.R\"
+                              ]
+                            }";
+    let hash = format!("sha256:{:x}", Sha256::new()
+        .chain_update(content)
+        .finalize());
+    let response = client.post(format!("/packet/{}", hash))
+        .body(content)
+        .header(ContentType::Text)
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response.content_type(), Some(ContentType::JSON));
+
+    let body = serde_json::from_str(&response.into_string().unwrap()).unwrap();
+    validate_success("null-response.json", &body);
+
+    body.get("data")
+        .expect("Data property present")
+        .as_null()
+        .expect("Null data");
+
+    // check packet now exists on server
+    let get_metadata_response = client.get("/metadata/20230427-150828-68772cee/json").dispatch();
+    assert_eq!(get_metadata_response.status(), Status::Ok);
+}
+
+#[test]
 fn catches_arbitrary_404() {
     let rocket = get_test_rocket();
     let client = Client::tracked(rocket).expect("valid rocket instance");


### PR DESCRIPTION
Adds `POST /packet<hash>` which should replicate the logic of:

```
location_path_import_metadata <- function(str, hash, root) {
  meta <- outpack_metadata_load(as_json(str))
  id <- meta$id
  hash_validate_data(str, hash, sprintf("metadata for '%s'", id))

  unknown_files <- root_list_unknown_files(meta$files$hash, root)
  if (length(unknown_files) > 0) {
    stop(
      sprintf("Can't import metadata for '%s', as files missing:\n%s",
              id, paste(sprintf("  - %s", unknown_files), collapse = "\n")))
  }
  unknown_packets <- root_list_unknown_packets(meta$depends$packet, TRUE, root)
  if (length(unknown_packets) > 0) {
    stop(sprintf(
      "Can't import metadata for '%s', as dependencies missing:\n%s",
      id, paste(sprintf("  - %s", unknown_packets), collapse = "\n")))
  }

  if (!is.null(root$config$core$path_archive)) {
    dst <- file.path(root$path, root$config$core$path_archive,
                     meta$name, id, meta$files$path)
    root$files$get(meta$files$hash, dst)
  }

  writeLines(str, file.path(root$path, ".outpack", "metadata", id))
  local_id <- local_location_id(root)
  time <- Sys.time()
  mark_packet_known(id, local_id, hash, time, root)
}
```

(minus the path archive bit since remotes will never have a path archive)