### PR TITLE
mrc-4364

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -108,7 +108,7 @@ async fn get_missing_files(root: &State<String>, hashes: Result<Json<Hashes>, Er
         .map(OutpackSuccess::from)
 }
 
-#[rocket::post("/file/<hash>", format = "plain", data = "<file>")]
+#[rocket::post("/file/<hash>", format = "binary", data = "<file>")]
 async fn add_file(
     root: &State<String>,
     hash: String,

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,7 +2,7 @@ use std::io::{ErrorKind};
 use rocket::{Build, catch, catchers, Request, Rocket, routes};
 use rocket::fs::TempFile;
 use rocket::State;
-use rocket::serde::json::{Json};
+use rocket::serde::json::{Error, Json};
 use rocket::serde::{Serialize, Deserialize};
 
 use crate::responses;
@@ -31,6 +31,15 @@ fn not_found(_req: &Request) -> Json<FailResponse> {
         error: String::from("NOT_FOUND"),
         detail: String::from("This route does not exist"),
         kind: Some(ErrorKind::NotFound),
+    }))
+}
+
+#[catch(400)]
+fn bad_request(_req: &Request) -> Json<FailResponse> {
+    Json(FailResponse::from(OutpackError {
+        error: String::from("BAD_REQUEST"),
+        detail: String::from("The request could not be understood by the server due to malformed syntax"),
+        kind: Some(ErrorKind::InvalidInput),
     }))
 }
 
@@ -84,14 +93,16 @@ async fn get_checksum(root: &State<String>, alg: Option<String>) -> OutpackResul
 }
 
 #[rocket::post("/packets/missing", format = "json", data = "<ids>")]
-async fn get_missing_packets(root: &State<String>, ids: Json<Ids>) -> OutpackResult<Vec<String>> {
+async fn get_missing_packets(root: &State<String>, ids: Result<Json<Ids>, Error<'_>>) -> OutpackResult<Vec<String>> {
+    let ids = ids?;
     metadata::get_missing_ids(root, &ids.ids, Some(ids.unpacked))
         .map_err(OutpackError::from)
         .map(OutpackSuccess::from)
 }
 
 #[rocket::post("/files/missing", format = "json", data = "<hashes>")]
-async fn get_missing_files(root: &State<String>, hashes: Json<Hashes>) -> OutpackResult<Vec<String>> {
+async fn get_missing_files(root: &State<String>, hashes: Result<Json<Hashes>, Error<'_>>) -> OutpackResult<Vec<String>> {
+    let hashes = hashes?;
     store::get_missing_files(root, &hashes.hashes)
         .map_err(OutpackError::from)
         .map(OutpackSuccess::from)
@@ -135,7 +146,7 @@ struct Hashes {
 pub fn api(root: String) -> Rocket<Build> {
     rocket::build()
         .manage(root)
-        .register("/", catchers![internal_error, not_found])
+        .register("/", catchers![internal_error, not_found, bad_request])
         .mount("/", routes![index, list_location_metadata, get_metadata,
             get_metadata_by_id, get_metadata_raw, get_file, get_checksum, get_missing_packets,
             get_missing_files, add_file, add_packet])

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -32,7 +32,7 @@ pub fn hash_parse(hash: &str) -> io::Result<ParsedHash> {
     Ok(ParsedHash { algorithm, value })
 }
 
-pub fn hash_data(data: &str, algorithm: HashAlgorithm) -> String {
+pub fn hash_data(data: &[u8], algorithm: HashAlgorithm) -> String {
     match algorithm {
         HashAlgorithm::md5 => format!("md5:{:x}", md5::compute(data)),
         HashAlgorithm::sha1 => format!("sha1:{:x}", Sha1::new()
@@ -50,7 +50,7 @@ pub fn hash_data(data: &str, algorithm: HashAlgorithm) -> String {
     }
 }
 
-pub fn validate_hash(root: &str, hash: &str, content: &str) -> Result<(), Error> {
+pub fn validate_hash(root: &str, hash: &str, content: &[u8]) -> Result<(), Error> {
     let parsed = hash_parse(hash)?;
     let alg = config::read_config(root)?.core.hash_algorithm;
     if parsed.algorithm != alg.to_string() {
@@ -83,7 +83,7 @@ mod tests {
     fn can_hash_data() {
         let data = "1234";
         let expected = format!("{:x}", md5::compute(data));
-        let res = hash_parse(&hash_data(data, HashAlgorithm::md5)).unwrap();
+        let res = hash_parse(&hash_data(data.as_bytes(), HashAlgorithm::md5)).unwrap();
         assert_eq!(res.algorithm, "md5");
         assert_eq!(res.value, expected);
     }
@@ -99,7 +99,7 @@ mod tests {
     #[test]
     fn validates_hash() {
         let hash = "badhash";
-        let res = validate_hash("tests/example", hash, "1234");
+        let res = validate_hash("tests/example", hash, "1234".as_bytes());
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(), "invalid hash 'badhash'");
     }
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn validates_hash_algorithm() {
         let hash = "md5:e9aa9f2212aba6fba4464212800a2927afa02eda688cf13131652da307e3d7c1";
-        let res = validate_hash("tests/example", hash, "1234");
+        let res = validate_hash("tests/example", hash, "1234".as_bytes());
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(), "Hash algorithm md5 does not match config. Expected sha256");
     }
@@ -115,7 +115,7 @@ mod tests {
     #[test]
     fn validates_hash_contents() {
         let hash = "sha256:e9aa9f2212aba6fba4464212800a2927afa02eda688cf13131652da307e3d7c1";
-        let res = validate_hash("tests/example", hash, "1234");
+        let res = validate_hash("tests/example", hash, "1234".as_bytes());
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().to_string(),
                    "Hash sha256:e9aa9f2212aba6fba4464212800a2927afa02eda688cf13131652da307e3d7c1 does not match file contents. Expected sha256:03ac674216f3e15c761ee1a5e255f067953623c8b388b4459e13f978d7c846f4");

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -196,7 +196,7 @@ pub fn get_ids_digest(root_path: &str, alg_name: Option<String>) -> io::Result<S
     let ids = get_ids(root_path, None)?;
     let id_string = get_sorted_id_string(ids);
 
-    Ok(hash::hash_data(&id_string.as_bytes(), hash_algorithm))
+    Ok(hash::hash_data(id_string.as_bytes(), hash_algorithm))
 }
 
 pub fn get_ids(root_path: &str, unpacked: Option<bool>) -> io::Result<Vec<String>> {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -196,7 +196,7 @@ pub fn get_ids_digest(root_path: &str, alg_name: Option<String>) -> io::Result<S
     let ids = get_ids(root_path, None)?;
     let id_string = get_sorted_id_string(ids);
 
-    Ok(hash::hash_data(&id_string, hash_algorithm))
+    Ok(hash::hash_data(&id_string.as_bytes(), hash_algorithm))
 }
 
 pub fn get_ids(root_path: &str, unpacked: Option<bool>) -> io::Result<Vec<String>> {
@@ -265,7 +265,7 @@ fn check_missing_dependencies(root: &str, packet: &Packet) -> Result<(), Error> 
 pub fn add_metadata(root: &str, data: &str, hash: &str) -> io::Result<()> {
     let packet: Packet = serde_json::from_str(data)?;
     let alg = config::read_config(root)?.core.hash_algorithm;
-    let expected_hash = hash::hash_data(data, alg);
+    let expected_hash = hash::hash_data(data.as_bytes(), alg);
     if expected_hash != hash {
         return Err(io::Error::new(io::ErrorKind::InvalidInput,
                                   format!("Hash of packet does not match:\n - expected: {}\n - found: {}",
@@ -436,7 +436,7 @@ mod tests {
                                 "orderly.R"
                               ]
                             }"#;
-        let hash = hash::hash_data(data, HashAlgorithm::sha256);
+        let hash = hash::hash_data(data.as_bytes(), HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         add_metadata(root_path, data, &hash).unwrap();
@@ -462,7 +462,7 @@ mod tests {
                                 "orderly.R"
                               ]
                             }"#;
-        let hash = hash::hash_data(data, HashAlgorithm::sha256);
+        let hash = hash::hash_data(data.as_bytes(), HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         add_metadata(root_path, data, &hash).unwrap();
@@ -489,7 +489,7 @@ mod tests {
                                 "orderly.R"
                               ]
                             }"#;
-        let hash = hash::hash_data(data, HashAlgorithm::sha256);
+        let hash = hash::hash_data(data.as_bytes(), HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         let now = SystemTime::now();
@@ -533,7 +533,7 @@ mod tests {
                                 "orderly.R"
                               ]
                             }"#;
-        let hash = hash::hash_data(data, HashAlgorithm::sha256);
+        let hash = hash::hash_data(data.as_bytes(), HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         let res = add_metadata(root_path, data, &hash);
@@ -561,7 +561,7 @@ mod tests {
                                 "orderly.R"
                               ]
                             }"#;
-        let hash = hash::hash_data(data, HashAlgorithm::sha256);
+        let hash = hash::hash_data(data.as_bytes(), HashAlgorithm::sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         let res = add_metadata(root_path, data, &hash);

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -48,6 +48,7 @@ impl<'r> Responder<'r, 'static> for OutpackError {
         let status = match kind {
             Some(ErrorKind::NotFound) => Status::NotFound,
             Some(ErrorKind::InvalidInput) => Status::BadRequest,
+            Some(ErrorKind::UnexpectedEof) => Status::BadRequest,
             _ =>  Status::InternalServerError
         };
         Response::build_from(json!(json).respond_to(req).unwrap())

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,6 +1,6 @@
 use std::io;
 use std::io::ErrorKind;
-use rocket::serde::{Deserialize, Serialize};
+use rocket::serde::{Deserialize, json, Serialize};
 use rocket::serde::json::{Json, json};
 use rocket::http::{ContentType, Status};
 use rocket::{Request, Response};
@@ -28,6 +28,15 @@ impl From<io::Error> for OutpackError {
             error: e.kind().to_string(),
             detail: e.to_string(),
             kind: Some(e.kind()),
+        }
+    }
+}
+
+impl From<json::Error<'_>> for OutpackError {
+    fn from(e: json::Error) -> Self {
+        match e {
+            json::Error::Io(err) => OutpackError::from(err),
+            json::Error::Parse(_str, err) =>  OutpackError::from(io::Error::from(err))
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -35,7 +35,7 @@ pub async fn put_file(root: &str, mut file: TempFile<'_>, hash: &str) -> io::Res
     let temp_dir = tempdir_in(root)?;
     let temp_path = temp_dir.path().join(hash);
     file.persist_to(&temp_path).await?;
-    let content = fs::read_to_string(&temp_path)?;
+    let content = fs::read(&temp_path)?;
     validate_hash(root, hash, &content)?;
     let path = file_path(root, hash)?;
     if !file_exists(root, hash)? {
@@ -76,7 +76,7 @@ mod tests {
         let mut temp_file = TempFile::Buffered {
             content: data
         };
-        let hash = hash_data(data, HashAlgorithm::sha256);
+        let hash = hash_data(data.as_bytes(), HashAlgorithm::sha256);
         temp_file.persist_to(root.join(&hash)).await.unwrap();
 
         let root_str = root.to_str().unwrap();

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -402,7 +402,7 @@ fn can_post_file() {
         .finalize());
     let response = client.post(format!("/file/{}", hash))
         .body(content)
-        .header(ContentType::Text)
+        .header(ContentType::Binary)
         .dispatch();
 
     assert_eq!(response.status(), Status::Ok);
@@ -430,7 +430,7 @@ fn file_post_handles_errors() {
     let content = "test";
     let response = client.post(format!("/file/badhash"))
         .body(content)
-        .header(ContentType::Text)
+        .header(ContentType::Binary)
         .dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -334,6 +334,9 @@ fn missing_packets_validates_request_body() {
         .header(ContentType::JSON)
         .dispatch();
 
+    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.content_type(), Some(ContentType::JSON));
+
     let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
     validate_error(&body, Some("EOF while parsing a value at line 1 column 0"));
 }
@@ -387,6 +390,9 @@ fn missing_files_validates_request_body() {
         .header(ContentType::JSON)
         .dispatch();
 
+    assert_eq!(response.status(), Status::BadRequest);
+    assert_eq!(response.content_type(), Some(ContentType::JSON));
+    
     let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
     validate_error(&body, Some("EOF while parsing a value at line 1 column 0"));
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -326,6 +326,17 @@ fn missing_packets_propagates_errors() {
     validate_error(&body, Some("Invalid packet id"));
 }
 
+#[test]
+fn missing_packets_validates_request_body() {
+    let rocket = get_test_rocket();
+    let client = Client::tracked(rocket).expect("valid rocket instance");
+    let response = client.post("/packets/missing")
+        .header(ContentType::JSON)
+        .dispatch();
+
+    let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
+    validate_error(&body, Some("EOF while parsing a value at line 1 column 0"));
+}
 
 #[derive(Serialize, Deserialize)]
 struct Hashes {
@@ -366,6 +377,18 @@ fn missing_files_propagates_errors() {
 
     let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
     validate_error(&body, Some("invalid hash"));
+}
+
+#[test]
+fn missing_files_validates_request_body() {
+    let rocket = get_test_rocket();
+    let client = Client::tracked(rocket).expect("valid rocket instance");
+    let response = client.post("/files/missing")
+        .header(ContentType::JSON)
+        .dispatch();
+
+    let body: Value = serde_json::from_str(&response.into_string().unwrap()).unwrap();
+    validate_error(&body, Some("EOF while parsing a value at line 1 column 0"));
 }
 
 #[test]


### PR DESCRIPTION
Validate request bodies so that POSTing invalid (or missing) json to an endpoint returns a json error reponse. Fixes https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-4364/Add-400-handler-to-outpack