### PR TITLE
Drop priority from locations

### DIFF
--- a/schema/config.json
+++ b/schema/config.json
@@ -40,14 +40,11 @@
                     "id": {
                         "$ref": "locationId.json"
                     },
-                    "priority": {
-                        "type": "number"
-                    },
                     "type": {
                         "enum": ["http", "local", "orphan", "path"]
                     }
                 },
-                "required": ["name", "id", "priority", "type"]
+                "required": ["name", "id", "type"]
             }
         }
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,6 @@ use strum_macros::{Display, EnumString};
 pub struct Location {
     pub name: String,
     pub id: String,
-    pub priority: i64,
 }
 
 #[allow(non_camel_case_types)]

--- a/src/location.rs
+++ b/src/location.rs
@@ -114,7 +114,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn packets_ordered_by_location_priority_then_id() {
+    fn packets_ordered_by_location_order_then_id() {
         let entries = read_locations("tests/example").unwrap();
         assert_eq!(entries[0].packet, "20170818-164847-7574883b");
         assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,9 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::{fs, io};
+use std::ffi::{OsString};
 use std::fs::{DirEntry};
 use std::path::{Path, PathBuf};
 use cached::cached_result;
 use cached::instant::SystemTime;
+use crate::config::Location;
 use crate::utils::time_as_num;
 
 use super::config;
@@ -26,6 +28,14 @@ cached_result! {
     }
 }
 
+fn get_order(location_config: &[Location], entry: &DirEntry) -> usize {
+    let id = entry.file_name();
+    location_config.iter()
+        .position(|l| OsString::from(&l.id) == id)
+        .unwrap()
+}
+
+
 pub fn read_location(path: PathBuf) -> io::Result<Vec<LocationEntry>> {
     let mut packets = fs::read_dir(path)?
         .filter_map(|e| e.ok())
@@ -43,11 +53,15 @@ pub fn read_locations(root_path: &str) -> io::Result<Vec<LocationEntry>> {
         .join(".outpack")
         .join("location");
 
-    let locations = fs::read_dir(path)?
+    let location_config = config::read_config(root_path)?.location;
+
+    let mut locations_sorted = fs::read_dir(path)?
         .filter_map(|r| r.ok())
         .collect::<Vec<DirEntry>>();
 
-    let packets = locations
+    locations_sorted.sort_by_key(|a| get_order(&location_config, a));
+
+    let packets = locations_sorted
         .iter()
         .map(|entry| read_location(entry.path()))
         // collect any errors at this point into a single result
@@ -98,6 +112,15 @@ mod tests {
     use std::time::{Duration, SystemTime};
     use crate::test_utils::tests::get_temp_outpack_root;
     use super::*;
+
+    #[test]
+    fn packets_ordered_by_location_priority_then_id() {
+        let entries = read_locations("tests/example").unwrap();
+        assert_eq!(entries[0].packet, "20170818-164847-7574883b");
+        assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");
+        assert_eq!(entries[2].packet, "20180220-095832-16a4bbed");
+        assert_eq!(entries[3].packet, "20180818-164043-7cdcde4b");
+    }
 
     #[test]
     fn can_find_local_id() {

--- a/src/location.rs
+++ b/src/location.rs
@@ -100,15 +100,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn packets_ordered_by_location_then_id() {
-        let entries = read_locations("tests/example").unwrap();
-        assert_eq!(entries[0].packet, "20170818-164847-7574883b");
-        assert_eq!(entries[1].packet, "20170818-164830-33e0ab01");
-        assert_eq!(entries[2].packet, "20180220-095832-16a4bbed");
-        assert_eq!(entries[3].packet, "20180818-164043-7cdcde4b");
-    }
-
-    #[test]
     fn can_find_local_id() {
         assert_eq!(get_local_location_id("tests/example").unwrap(), "be7a7bcb");
     }

--- a/tests/bad-example/.outpack/config.json
+++ b/tests/bad-example/.outpack/config.json
@@ -10,7 +10,6 @@
     {
       "name": "another",
       "id": "ae7a7bcb",
-      "priority": 1,
       "type": "file",
       "args": []
     }

--- a/tests/example/.outpack/config.json
+++ b/tests/example/.outpack/config.json
@@ -10,14 +10,12 @@
     {
       "name": "local",
       "id": "be7a7bcb",
-      "priority": 0,
       "type": "local",
       "args": []
     },
     {
       "name": "another",
       "id": "ae7a7bcb",
-      "priority": 1,
       "type": "file",
       "args": []
     }


### PR DESCRIPTION
Pairs with an orderly2 PR (https://github.com/mrc-ide/orderly2/pull/57), but this one should be merged first.

Walking back the "priority" idea for locations, it was not actually useful and not referenced anywhere yet, so just removing it. It looks like the ordering returned from disk is arbitrary or locale/platform dependent so I've ordered based on how they appear in the config which makes the tests stable (it is what orderly2 does too, but it also does not matter)