### PR TITLE
Use temporary file location in same fs

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -34,7 +34,7 @@ pub fn get_missing_files(root: &str, wanted: &[String]) -> io::Result<Vec<String
 pub async fn put_file(root: &str, mut file: TempFile<'_>, hash: &str) -> io::Result<()> {
     let temp_dir = tempdir_in(root)?;
     let temp_path = temp_dir.path().join(hash);
-    file.persist_to(&temp_path).await?;
+    file.copy_to(&temp_path).await?;
     let content = fs::read(&temp_path)?;
     validate_hash(root, hash, &content)?;
     let path = file_path(root, hash)?;


### PR DESCRIPTION
Backing out of the approach used in: 70c0403 ([files](https://github.com/mrc-ide/outpack_server/tree/70c0403141851181f295a429ae9ac08d4174f3ed))

> This PR uses a temporary location in the same directory as the hash itself, guaranteeing that the rename is possible due to not crossing filesystem boundary.

Now we just do copy_to rather than persist_to, which will work in a docker context