### PR TITLE
Tidy up api start

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -183,22 +183,22 @@ pub fn preflight(root_path: &str) -> Result<(), String> {
     if !Path::new(&root_path).join(".outpack").exists() {
         return Err(format!("Outpack root not found at '{}'", root_path))
     }
-    let config = config::read_config(&root_path)
+    let config = config::read_config(root_path)
         .map_err(|e| format!("Failed to read outpack config from '{}': {}", root_path, e))?;
     check_config(&config)
 }
 
-fn api_build(root: String) -> Rocket<Build> {
+fn api_build(root: &str) -> Rocket<Build> {
     rocket::build()
-        .manage(root)
+        .manage(String::from(root))
         .register("/", catchers![internal_error, not_found, bad_request])
         .mount("/", routes![index, list_location_metadata, get_metadata,
                             get_metadata_by_id, get_metadata_raw, get_file, get_checksum, get_missing_packets,
                             get_missing_files, add_file, add_packet])
 }
 
-pub fn api(root: String) -> Result<Rocket<Build>, String> {
-    preflight(&root)?;
+pub fn api(root: &str) -> Result<Rocket<Build>, String> {
+    preflight(root)?;
     Ok(api_build(root))
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,14 +25,6 @@ pub struct ApiRoot {
     pub schema_version: String,
 }
 
-impl ApiRoot {
-    pub fn new(schema_version: String) -> ApiRoot {
-        ApiRoot {
-            schema_version
-        }
-    }
-}
-
 #[catch(500)]
 fn internal_error(_req: &Request) -> Json<FailResponse> {
     Json(FailResponse::from(OutpackError {
@@ -63,7 +55,7 @@ fn bad_request(_req: &Request) -> Json<FailResponse> {
 #[rocket::get("/")]
 fn index(root: &State<String>) -> OutpackResult<ApiRoot> {
     config::read_config(root)
-        .map(|r| ApiRoot::new(r.schema_version))
+        .map(|r| ApiRoot{schema_version: r.schema_version})
         .map_err(OutpackError::from)
         .map(OutpackSuccess::from)
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -176,7 +176,7 @@ pub fn check_config(config: &config::Config) -> Result<(), String> {
     if config.core.path_archive.is_some() {
         return Err(format!("Outpack must be configured to *not* use an archive, but your path_archive is '{}'", config.core.path_archive.as_ref().unwrap()));
     }
-    return Ok(())
+    Ok(())
 }
 
 pub fn preflight(root_path: &str) -> Result<(), String> {

--- a/src/bin/outpack_server.rs
+++ b/src/bin/outpack_server.rs
@@ -1,6 +1,5 @@
 use getopts::Options;
 use std::env;
-use std::path::Path;
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} [options]", program);
@@ -23,10 +22,10 @@ fn parse_args(args: &[String]) -> Option<String> {
 
 #[allow(unused_must_use)]
 async fn start_app(root_path: String) -> Result<(), rocket::Error> {
-    if !Path::new(&root_path).join(".outpack").exists() {
-        panic!("Outpack root not found at {}", root_path)
+    match outpack::api::api(root_path) {
+        Err(error) => {panic!("{}", error);}
+        Ok(api) => {api.launch().await;}
     }
-    outpack::api::api(root_path).launch().await;
     Ok(())
 }
 

--- a/src/bin/outpack_server.rs
+++ b/src/bin/outpack_server.rs
@@ -21,7 +21,7 @@ fn parse_args(args: &[String]) -> Option<String> {
 }
 
 #[allow(unused_must_use)]
-async fn start_app(root_path: String) -> Result<(), rocket::Error> {
+async fn start_app(root_path: &str) -> Result<(), rocket::Error> {
     match outpack::api::api(root_path) {
         Err(error) => {panic!("{}", error);}
         Ok(api) => {api.launch().await;}
@@ -35,7 +35,7 @@ async fn main() -> Result<(), rocket::Error> {
     let args = env::args().collect::<Vec<_>>();
     let root = parse_args(&args);
     if let Some(root_path) = root {
-        start_app(root_path).await;
+        start_app(&root_path).await;
     }
     Ok(())
 }
@@ -63,6 +63,6 @@ mod tests {
     #[should_panic]
     #[allow(unused_must_use)]
     async fn panics_if_outpack_not_found() {
-        start_app(String::from("badpath")).await;
+        start_app("badpath").await;
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,14 +8,19 @@ use crate::hash::{HashAlgorithm};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Location {
+    // Practically, doing anything with locations (therefore needing
+    // access to the "type" and "args" fields) is going to require we
+    // know how to deserialise into a union type; for example
+    // https://stackoverflow.com/q/66964692
     pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Core {
+    pub hash_algorithm: HashAlgorithm,
     pub path_archive: Option<String>,
     pub use_file_store: bool,
-    pub hash_algorithm: HashAlgorithm,
+    pub require_complete_tree: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -23,19 +28,6 @@ pub struct Config {
     pub schema_version: String,
     pub location: Vec<Location>,
     pub core: Core,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Root {
-    pub schema_version: String,
-}
-
-impl Root {
-    pub fn new(schema_version: String) -> Root {
-        Root {
-            schema_version
-        }
-    }
 }
 
 pub fn read_config(root_path: &str) -> Result<Config, Error> {
@@ -54,9 +46,10 @@ mod tests {
     #[test]
     fn can_read_config() {
         let cfg = read_config("tests/example").unwrap();
+        assert_eq!(cfg.schema_version, "0.0.1");
         assert_eq!(cfg.core.hash_algorithm, HashAlgorithm::Sha256);
         assert!(cfg.core.use_file_store);
+        assert!(cfg.core.require_complete_tree);
         assert!(cfg.core.path_archive.is_none());
     }
 }
-

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -38,7 +38,7 @@ fn get_test_dir() -> String {
 
 fn get_test_rocket() -> Rocket<Build> {
     let root = get_test_dir();
-    outpack::api::api(root).unwrap()
+    outpack::api::api(&root).unwrap()
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn can_get_index() {
 
 #[test]
 fn error_if_cant_get_index() {
-    let res = outpack::api::api(String::from("bad-root"));
+    let res = outpack::api::api("bad-root");
     assert!(res.is_err());
     assert_eq!(res.unwrap_err(),
                String::from("Outpack root not found at 'bad-root'"));
@@ -113,7 +113,7 @@ fn can_list_location_metadata() {
 
 #[test]
 fn handles_location_metadata_errors() {
-    let rocket = outpack::api::api(String::from("tests/bad-example")).unwrap();
+    let rocket = outpack::api::api("tests/bad-example").unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -173,7 +173,7 @@ fn can_list_metadata_from_date() {
 
 #[test]
 fn handles_metadata_errors() {
-    let rocket = outpack::api::api(String::from("tests/bad-example")).unwrap();
+    let rocket = outpack::api::api("tests/bad-example").unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/packit/metadata").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -395,7 +395,7 @@ fn missing_files_validates_request_body() {
 #[test]
 fn can_post_file() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone()).unwrap();
+    let rocket = outpack::api::api(&root).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = "test";
     let hash = format!("sha256:{:x}", Sha256::new()
@@ -426,7 +426,7 @@ fn can_post_file() {
 #[test]
 fn file_post_handles_errors() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone()).unwrap();
+    let rocket = outpack::api::api(&root).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = "test";
     let response = client.post(format!("/file/md5:bad4a54"))
@@ -444,7 +444,7 @@ fn file_post_handles_errors() {
 #[test]
 fn can_post_metadata() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone()).unwrap();
+    let rocket = outpack::api::api(&root).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = r#"{
                              "schema_version": "0.0.1",

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -38,7 +38,7 @@ fn get_test_dir() -> String {
 
 fn get_test_rocket() -> Rocket<Build> {
     let root = get_test_dir();
-    outpack::api::api(root)
+    outpack::api::api(root).unwrap()
 }
 
 #[test]
@@ -56,7 +56,7 @@ fn can_get_index() {
 
 #[test]
 fn error_if_cant_get_index() {
-    let rocket = outpack::api::api(String::from("bad-root"));
+    let rocket = outpack::api::api(String::from("bad-root")).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/").dispatch();
 
@@ -118,7 +118,7 @@ fn can_list_location_metadata() {
 
 #[test]
 fn handles_location_metadata_errors() {
-    let rocket = outpack::api::api(String::from("tests/bad-example"));
+    let rocket = outpack::api::api(String::from("tests/bad-example")).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/metadata/list").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -178,7 +178,7 @@ fn can_list_metadata_from_date() {
 
 #[test]
 fn handles_metadata_errors() {
-    let rocket = outpack::api::api(String::from("tests/bad-example"));
+    let rocket = outpack::api::api(String::from("tests/bad-example")).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let response = client.get("/packit/metadata").dispatch();
     assert_eq!(response.status(), Status::InternalServerError);
@@ -400,7 +400,7 @@ fn missing_files_validates_request_body() {
 #[test]
 fn can_post_file() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone());
+    let rocket = outpack::api::api(root.clone()).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = "test";
     let hash = format!("sha256:{:x}", Sha256::new()
@@ -431,7 +431,7 @@ fn can_post_file() {
 #[test]
 fn file_post_handles_errors() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone());
+    let rocket = outpack::api::api(root.clone()).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = "test";
     let response = client.post(format!("/file/md5:bad4a54"))
@@ -449,7 +449,7 @@ fn file_post_handles_errors() {
 #[test]
 fn can_post_metadata() {
     let root = get_test_dir();
-    let rocket = outpack::api::api(root.clone());
+    let rocket = outpack::api::api(root.clone()).unwrap();
     let client = Client::tracked(rocket).expect("valid rocket instance");
     let content = r#"{
                              "schema_version": "0.0.1",

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -56,15 +56,10 @@ fn can_get_index() {
 
 #[test]
 fn error_if_cant_get_index() {
-    let rocket = outpack::api::api(String::from("bad-root")).unwrap();
-    let client = Client::tracked(rocket).expect("valid rocket instance");
-    let response = client.get("/").dispatch();
-
-    assert_eq!(response.status(), Status::NotFound);
-    assert_eq!(response.content_type(), Some(ContentType::JSON));
-
-    let body = serde_json::from_str(&response.into_string().unwrap()).unwrap();
-    validate_error(&body, Some("No such file or directory"));
+    let res = outpack::api::api(String::from("bad-root"));
+    assert!(res.is_err());
+    assert_eq!(res.unwrap_err(),
+               String::from("Outpack root not found at 'bad-root'"));
 }
 
 #[test]


### PR DESCRIPTION
* moves the existing Root class into the api as it's not really the outpack root, but the serde template for json serialisation.
* validates that the outpack config has suitable values for use with the server

~Merge after #30, contains those commits~