### PR TITLE
mrc-4558: Create an outpack root from the cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM debian:bookworm-slim
 RUN  apt-get -yq update && \
      apt-get -yqq install openssh-client git
 
-COPY --from=builder /usr/local/cargo/bin/outpack_server /usr/local/bin/outpack_server
+COPY --from=builder /usr/local/cargo/bin/* /usr/local/bin/
 COPY --from=builder /usr/src/outpack_server/Rocket.toml .
 COPY start-with-wait /usr/local/bin
 EXPOSE 8000

--- a/src/bin/outpack_init.rs
+++ b/src/bin/outpack_init.rs
@@ -15,7 +15,7 @@ struct InitOptions {
 
 fn usage(program: &str, opts: &Options) -> String {
     let brief = format!("Usage: {} [options]", program);
-    format!("{}", opts.usage(&brief))
+    opts.usage(&brief).to_string()
 }
 
 fn parse_args(args: &[String]) -> Result<InitOptions, String> {

--- a/src/bin/outpack_init.rs
+++ b/src/bin/outpack_init.rs
@@ -1,0 +1,59 @@
+extern crate core;
+
+use getopts::Options;
+use std::env;
+
+
+use outpack::init::outpack_init;
+
+struct InitOptions {
+    path: String,
+    path_archive: Option<String>,
+    use_file_store: bool,
+    require_complete_tree: bool,
+}
+
+fn usage(program: &str, opts: &Options) -> String {
+    let brief = format!("Usage: {} [options]", program);
+    format!("{}", opts.usage(&brief))
+}
+
+fn parse_args(args: &[String]) -> Result<InitOptions, String> {
+    let program = args[0].clone();
+    let mut opts = Options::new();
+    opts.optopt("", "path-archive", "path to the archive", "path");
+    opts.optflag("", "use-file-store", "use a file store");
+    opts.optflag("", "require-complete-tree", "require a complete tree");
+    opts.reqopt("", "path", "path to the outpack path", "path");
+    opts.optflag("h", "help", "print this help");
+
+    let res = opts.parse(&args[1..]).map_err(|_| usage(&program, &opts))?;
+    if res.opt_present("h") {
+        return Err(usage(&program, &opts));
+    }
+    let use_file_store = res.opt_present("use-file-store");
+    let require_complete_tree = res.opt_present("require-complete-tree");
+    let path = res.opt_str("path").unwrap();
+    let path_archive = if res.opt_present("path-archive") {
+        Some(res.opt_str("path-archive").unwrap())
+    } else {
+        None
+    };
+    Ok(InitOptions{path, path_archive, use_file_store, require_complete_tree})
+}
+
+fn do_init(opts: InitOptions) -> Result<(), String> {
+    outpack_init(
+        &opts.path,
+        opts.path_archive,
+        opts.use_file_store,
+        opts.require_complete_tree
+    ).map_err(|e| e.to_string())
+}
+
+fn main() -> Result<(), String> {
+    let args = env::args().collect::<Vec<_>>();
+    let result = parse_args(&args)?;
+    do_init(result)?;
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,9 @@ impl Config {
         require_complete_tree: bool,
     ) -> Result<Self, Error> {
         if !use_file_store && path_archive.is_none() {
-            todo!();
-            // return Error(InvalidInput, "...");
+            return Err(Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "If 'path_archive' is None, then use_file_store must be true"));
         }
         let hash_algorithm = HashAlgorithm::Sha256;
         let core = Core {
@@ -90,5 +91,15 @@ mod tests {
         fs::create_dir_all(path.join(".outpack")).unwrap();
         write_config(&cfg, path_str).unwrap();
         assert_eq!(read_config(path_str).unwrap(), cfg);
+    }
+
+    #[test]
+    fn need_some_storage() {
+        let cfg = Config::new(None, false, false);
+        assert!(cfg.is_err());
+        assert_eq!(
+            cfg.unwrap_err().to_string(),
+            "If 'path_archive' is None, then use_file_store must be true"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,12 +1,12 @@
 use serde::{Deserialize, Serialize};
-use std::fs::File;
+use std::fs;
+use std::io::Error;
+use std::path::Path;
 use std::result::Result;
-use std::io::{Error};
-use std::path::{Path};
 
-use crate::hash::{HashAlgorithm};
+use crate::hash::HashAlgorithm;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Location {
     // Practically, doing anything with locations (therefore needing
     // access to the "type" and "args" fields) is going to require we
@@ -15,7 +15,7 @@ pub struct Location {
     pub name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Core {
     pub hash_algorithm: HashAlgorithm,
     pub path_archive: Option<String>,
@@ -23,24 +23,54 @@ pub struct Core {
     pub require_complete_tree: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Config {
-    pub location: Vec<Location>,
     pub core: Core,
+    pub location: Vec<Location>,
+}
+
+impl Config {
+    pub fn new(
+        path_archive: Option<String>,
+        use_file_store: bool,
+        require_complete_tree: bool,
+    ) -> Result<Self, Error> {
+        if !use_file_store && path_archive.is_none() {
+            todo!();
+            // return Error(InvalidInput, "...");
+        }
+        let hash_algorithm = HashAlgorithm::Sha256;
+        let core = Core {
+            hash_algorithm,
+            path_archive,
+            use_file_store,
+            require_complete_tree,
+        };
+        let location: Vec<Location> = Vec::new();
+        Ok(Config { core, location })
+    }
 }
 
 pub fn read_config(root_path: &str) -> Result<Config, Error> {
-    let path = Path::new(root_path)
-        .join(".outpack")
-        .join("config.json");
-    let config_file = File::open(path)?;
+    let path = Path::new(root_path).join(".outpack").join("config.json");
+    let config_file = fs::File::open(path)?;
     let config: Config = serde_json::from_reader(config_file)?;
     Ok(config)
+}
+
+pub fn write_config(config: &Config, root_path: &str) -> Result<(), Error> {
+    // assume .outpack exists
+    let path_config = Path::new(root_path).join(".outpack").join("config.json");
+    fs::File::create(&path_config)?;
+    let json = serde_json::to_string(&config)?;
+    fs::write(path_config, json)?;
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile;
 
     #[test]
     fn can_read_config() {
@@ -49,5 +79,16 @@ mod tests {
         assert!(cfg.core.use_file_store);
         assert!(cfg.core.require_complete_tree);
         assert!(cfg.core.path_archive.is_none());
+    }
+
+    #[test]
+    fn can_write_config() {
+        let cfg = Config::new(None, true, true).unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path();
+        let path_str = path.to_str().unwrap();
+        fs::create_dir_all(path.join(".outpack")).unwrap();
+        write_config(&cfg, path_str).unwrap();
+        assert_eq!(read_config(path_str).unwrap(), cfg);
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -24,8 +24,8 @@ pub fn outpack_init(
     } else {
         fs::create_dir_all(&path_outpack)?;
         config::write_config(&cfg, path)?;
-        fs::create_dir_all(&path_outpack.join("location").join("local"))?;
-        fs::create_dir_all(&path_outpack.join("metadata"))?;
+        fs::create_dir_all(path_outpack.join("location").join("local"))?;
+        fs::create_dir_all(path_outpack.join("metadata"))?;
         if use_file_store {
             fs::create_dir_all(path_outpack.join("files"))?;
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,0 +1,87 @@
+use std::fs;
+use std::io::Error;
+use std::path::Path; // still using io errors here due to config
+
+use crate::config;
+
+pub fn outpack_init(
+    path: &str,
+    path_archive: Option<String>,
+    use_file_store: bool,
+    require_complete_tree: bool,
+) -> Result<(), Error> {
+    let path_outpack = Path::new(path).join(".outpack");
+    let cfg = config::Config::new(path_archive, use_file_store, require_complete_tree)?;
+
+    if path_outpack.exists() {
+        let prev = config::read_config(path)?;
+        if cfg.core != prev.core {
+            return Err(Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Trying to change config on reinitialisation",
+            ));
+        }
+    } else {
+        fs::create_dir_all(&path_outpack)?;
+        config::write_config(&cfg, path)?;
+        fs::create_dir_all(&path_outpack.join("location").join("local"))?;
+        fs::create_dir_all(&path_outpack.join("metadata"))?;
+        if use_file_store {
+            fs::create_dir_all(path_outpack.join("files"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile;
+
+    #[test]
+    fn can_create_empty_config() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path();
+        let path_str = path.to_str().unwrap();
+        let res = outpack_init(path_str, None, true, true);
+        assert!(res.is_ok());
+        assert_eq!(
+            config::read_config(path_str).unwrap(),
+            config::Config::new(None, true, true).unwrap()
+        );
+    }
+
+    #[test]
+    fn can_reinit_an_existing_repo() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path();
+        let path_str = path.to_str().unwrap();
+        let res = outpack_init(path_str, Some(String::from("archive")), false, false);
+        assert!(res.is_ok());
+        assert_eq!(
+            config::read_config(path_str).unwrap(),
+            config::Config::new(Some(String::from("archive")), false, false).unwrap()
+        );
+
+        let res = outpack_init(path_str, Some(String::from("archive")), false, false);
+        assert!(res.is_ok());
+        assert_eq!(
+            config::read_config(path_str).unwrap(),
+            config::Config::new(Some(String::from("archive")), false, false).unwrap()
+        );
+    }
+
+    #[test]
+    fn error_if_config_has_changed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path();
+        let path_str = path.to_str().unwrap();
+        outpack_init(path_str, Some(String::from("archive")), false, false).unwrap();
+        let res = outpack_init(path_str, None, true, true);
+        assert!(res.is_err());
+        assert_eq!(
+            res.unwrap_err().to_string(),
+            "Trying to change config on reinitialisation"
+        )
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,6 +29,9 @@ pub fn outpack_init(
         if use_file_store {
             fs::create_dir_all(path_outpack.join("files"))?;
         }
+        if let Some(path_archive) = cfg.core.path_archive {
+            fs::create_dir_all(Path::new(path).join(path_archive))?;
+        }
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod api;
 pub mod query;
 pub mod index;
+pub mod init;
 
 mod responses;
 mod location;


### PR DESCRIPTION
This stretches our cli framework to the limit, it's getting a bit junky now, but the clap refactor can happen later.

This PR does a basic initialisation of an outpack root from the rust cli. This will simplify the deployment as we won't need another container, we can just use the server one we have - we might also update the api to create the directory as it starts, perhaps as an option.

Possible improvements would include indicating which configuration options have changed rather than just bailing.

Pretty pleased to have been able to do this with minimal googling now, stuck on a train crawling out of london...