### PR TITLE
mrc-4549: Add support for other comparison operators

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -61,16 +61,6 @@ pub struct DependencyFile {
     there: String,
 }
 
-impl Packet {
-    #[allow(dead_code)]
-    pub fn get_parameter(&self, param_name: &str) ->  Option<&serde_json::Value> {
-        match &(self.parameters) {
-            Some(params) => params.get(param_name),
-            None => None
-        }
-    }
-}
-
 cached_result! {
     METADATA_CACHE: cached::UnboundCache<PathBuf, Packet> = cached::UnboundCache::new();
     fn read_metadata(path: PathBuf) -> io::Result<Packet> = {

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -11,7 +11,7 @@ funcNames          = _{ latest }
 latest             =  { "latest" }
 
 infixExpression = { lookup ~ infixFunction ~ lookupValue }
-infixFunction   = { ("=" | "!" | "<" | ">"){2} }
+infixFunction   = @{ ("=" | "!" | "<" | ">"){1,2} }
 
 lookup   = { lookupId | lookupName | lookupParam }
 lookupId = { "id" }

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -226,90 +226,48 @@ mod tests {
         assert_eq!(params.get("pull_data").unwrap(),
                    &(serde_json::Value::Bool(true)));
 
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::Equal,
-                                      &Literal::Number(0.001)));
-        assert!(!packet.test_parameter("tolerance",
-                                       &Test::Equal,
-                                       &Literal::Number(0.002)));
-        assert!(!packet.test_parameter("tolerance",
-                                       &Test::Equal,
-                                       &Literal::String("0.001")));
+        macro_rules! test_param {
+            ( $( $name:literal, $test:expr, $lit:expr => $result:expr )* ) => {
+                $(
+                assert_eq!(packet.test_parameter($name, $test, $lit), $result);
+                )*
+            };
+        }
 
-        assert!(packet.test_parameter("disease",
-                                      &Test::Equal,
-                                      &Literal::String("YF")));
-        assert!(!packet.test_parameter("disease",
-                                       &Test::Equal,
-                                       &Literal::String("HepB")));
-        assert!(!packet.test_parameter("disease",
-                                       &Test::Equal,
-                                       &Literal::Number(0.5)));
+        test_param!(
+            "tolerance", &Test::Equal, &Literal::Number(0.001)   => true
+            "tolerance", &Test::Equal, &Literal::Number(0.002)   => false
+            "tolerance", &Test::Equal, &Literal::String("0.001") => false
 
-        assert!(packet.test_parameter("size",
-                                      &Test::Equal,
-                                      &Literal::Number(10f64)));
-        assert!(packet.test_parameter("size",
-                                      &Test::Equal,
-                                      &Literal::Number(10.0)));
-        assert!(!packet.test_parameter("size",
-                                       &Test::Equal,
-                                       &Literal::Number(9f64)));
-        assert!(!packet.test_parameter("size",
-                                       &Test::Equal,
-                                       &Literal::Bool(true)));
+            "disease", &Test::Equal, &Literal::String("YF")   => true
+            "disease", &Test::Equal, &Literal::String("HepB") => false
+            "disease", &Test::Equal, &Literal::Number(0.5)    => false
 
-        assert!(packet.test_parameter("pull_data",
-                                      &Test::Equal,
-                                      &Literal::Bool(true)));
-        assert!(!packet.test_parameter("pull_data",
-                                       &Test::Equal,
-                                       &Literal::Bool(false)));
-        assert!(!packet.test_parameter("pull_data",
-                                       &Test::Equal,
-                                       &Literal::String("true")));
+            "size", &Test::Equal, &Literal::Number(10f64) => true
+            "size", &Test::Equal, &Literal::Number(10.0)  => true
+            "size", &Test::Equal, &Literal::Number(9f64)  => false
+            "size", &Test::Equal, &Literal::Bool(true)    => false
 
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::NotEqual,
-                                      &Literal::Number(0.002)));
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::LessThan,
-                                      &Literal::Number(0.002)));
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::LessThanOrEqual,
-                                      &Literal::Number(0.002)));
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::GreaterThan,
-                                      &Literal::Number(0.000)));
-        assert!(packet.test_parameter("tolerance",
-                                      &Test::GreaterThanOrEqual,
-                                      &Literal::Number(0.000)));
-        assert!(!packet.test_parameter("tolerance",
-                                       &Test::LessThan,
-                                       &Literal::Number(0.000)));
-        assert!(!packet.test_parameter("tolerance",
-                                       &Test::LessThanOrEqual,
-                                       &Literal::Number(0.000)));
+            "pull_data", &Test::Equal, &Literal::Bool(true)     => true
+            "pull_data", &Test::Equal, &Literal::Bool(false)    => false
+            "pull_data", &Test::Equal, &Literal::String("true") => false
 
-        assert!(!packet.test_parameter("pull_data",
-                                       &Test::LessThan,
-                                       &Literal::Bool(true)));
-        assert!(!packet.test_parameter("pull_data",
-                                       &Test::LessThan,
-                                       &Literal::Bool(false)));
+            "tolerance", &Test::NotEqual,           &Literal::Number(0.002) => true
+            "tolerance", &Test::LessThan,           &Literal::Number(0.002) => true
+            "tolerance", &Test::LessThanOrEqual,    &Literal::Number(0.002) => true
+            "tolerance", &Test::GreaterThan,        &Literal::Number(0.000) => true
+            "tolerance", &Test::GreaterThanOrEqual, &Literal::Number(0.000) => true
+            "tolerance", &Test::LessThan,           &Literal::Number(0.000) => false
+            "tolerance", &Test::LessThanOrEqual,    &Literal::Number(0.000) => false
 
-        assert!(!packet.test_parameter("disease",
-                                       &Test::LessThan,
-                                       &Literal::String("YF")));
-        assert!(!packet.test_parameter("disease",
-                                       &Test::LessThanOrEqual,
-                                       &Literal::String("YF")));
-        assert!(!packet.test_parameter("disease",
-                                       &Test::GreaterThan,
-                                       &Literal::String("YF")));
-        assert!(!packet.test_parameter("disease",
-                                       &Test::GreaterThanOrEqual,
-                                       &Literal::String("YF")));
+            "pull_data", &Test::LessThan, &Literal::Bool(true)  => false
+            "pull_data", &Test::LessThan, &Literal::Bool(false) => false
+
+            "disease", &Test::LessThan,           &Literal::String("YF") => false
+            "disease", &Test::LessThanOrEqual,    &Literal::String("YF") => false
+            "disease", &Test::GreaterThan,        &Literal::String("YF") => false
+            "disease", &Test::GreaterThanOrEqual, &Literal::String("YF") => false
+        );
     }
 
     #[test]

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -229,7 +229,11 @@ mod tests {
         macro_rules! test_param {
             ( $( $name:literal, $test:expr, $lit:expr => $result:expr )* ) => {
                 $(
-                assert_eq!(packet.test_parameter($name, $test, $lit), $result);
+                if $result {
+                    assert!(packet.test_parameter($name, $test, $lit));
+                } else {
+                    assert!(!packet.test_parameter($name, $test, $lit));
+                }
                 )*
             };
         }

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -225,35 +225,90 @@ mod tests {
         assert_eq!(params.get("pull_data").unwrap(),
                    &(serde_json::Value::Bool(true)));
 
-        // assert!(packet.parameter_equals("tolerance",
-        //                                 &Literal::Number(0.001)));
-        // assert!(!packet.parameter_equals("tolerance",
-        //                                  &Literal::Number(0.002)));
-        // assert!(!packet.parameter_equals("tolerance",
-        //                                  &Literal::String("0.001")));
-        //
-        // assert!(packet.parameter_equals("disease",
-        //                                 &Literal::String("YF")));
-        // assert!(!packet.parameter_equals("disease",
-        //                                  &Literal::String("HepB")));
-        // assert!(!packet.parameter_equals("disease",
-        //                                  &Literal::Number(0.5)));
-        //
-        // assert!(packet.parameter_equals("size",
-        //                                 &Literal::Number(10f64)));
-        // assert!(packet.parameter_equals("size",
-        //                                 &Literal::Number(10.0)));
-        // assert!(!packet.parameter_equals("size",
-        //                                  &Literal::Number(9f64)));
-        // assert!(!packet.parameter_equals("size",
-        //                                  &Literal::Bool(true)));
-        //
-        // assert!(packet.parameter_equals("pull_data",
-        //                                 &Literal::Bool(true)));
-        // assert!(!packet.parameter_equals("pull_data",
-        //                                  &Literal::Bool(false)));
-        // assert!(!packet.parameter_equals("pull_data",
-        //                                  &Literal::String("true")));
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::Equal,
+                                      &Literal::Number(0.001)));
+        assert!(!packet.test_parameter("tolerance",
+                                       &Test::Equal,
+                                       &Literal::Number(0.002)));
+        assert!(!packet.test_parameter("tolerance",
+                                       &Test::Equal,
+                                       &Literal::String("0.001")));
+
+        assert!(packet.test_parameter("disease",
+                                      &Test::Equal,
+                                      &Literal::String("YF")));
+        assert!(!packet.test_parameter("disease",
+                                       &Test::Equal,
+                                       &Literal::String("HepB")));
+        assert!(!packet.test_parameter("disease",
+                                       &Test::Equal,
+                                       &Literal::Number(0.5)));
+
+        assert!(packet.test_parameter("size",
+                                      &Test::Equal,
+                                      &Literal::Number(10f64)));
+        assert!(packet.test_parameter("size",
+                                      &Test::Equal,
+                                      &Literal::Number(10.0)));
+        assert!(!packet.test_parameter("size",
+                                       &Test::Equal,
+                                       &Literal::Number(9f64)));
+        assert!(!packet.test_parameter("size",
+                                       &Test::Equal,
+                                       &Literal::Bool(true)));
+
+        assert!(packet.test_parameter("pull_data",
+                                      &Test::Equal,
+                                      &Literal::Bool(true)));
+        assert!(!packet.test_parameter("pull_data",
+                                       &Test::Equal,
+                                       &Literal::Bool(false)));
+        assert!(!packet.test_parameter("pull_data",
+                                       &Test::Equal,
+                                       &Literal::String("true")));
+
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::NotEqual,
+                                      &Literal::Number(0.002)));
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::LessThan,
+                                      &Literal::Number(0.002)));
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::LessThanOrEqual,
+                                      &Literal::Number(0.002)));
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::GreaterThan,
+                                      &Literal::Number(0.000)));
+        assert!(packet.test_parameter("tolerance",
+                                      &Test::GreaterThanOrEqual,
+                                      &Literal::Number(0.000)));
+        assert!(!packet.test_parameter("tolerance",
+                                       &Test::LessThan,
+                                       &Literal::Number(0.000)));
+        assert!(!packet.test_parameter("tolerance",
+                                       &Test::LessThanOrEqual,
+                                       &Literal::Number(0.000)));
+
+        assert!(!packet.test_parameter("pull_data",
+                                       &Test::LessThan,
+                                       &Literal::Bool(true)));
+        assert!(!packet.test_parameter("pull_data",
+                                       &Test::LessThan,
+                                       &Literal::Bool(false)));
+
+        assert!(!packet.test_parameter("disease",
+                                       &Test::LessThan,
+                                       &Literal::String("YF")));
+        assert!(!packet.test_parameter("disease",
+                                       &Test::LessThanOrEqual,
+                                       &Literal::String("YF")));
+        assert!(!packet.test_parameter("disease",
+                                       &Test::GreaterThan,
+                                       &Literal::String("YF")));
+        assert!(!packet.test_parameter("disease",
+                                       &Test::GreaterThanOrEqual,
+                                       &Literal::String("YF")));
     }
 
     #[test]

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -88,19 +88,20 @@ impl Packet {
         }
     }
 
-    /// Check if a packet parameter is equal to a test value
+    /// Run a comparison test on a packet parameter and a test value
     ///
-    /// This will get the parameter `param_name` from the current Packet and then test for
-    /// equality of the test value `value`.
+    /// This will get the parameter `param_name` from the current Packet and then run the
+    /// specified comparison `test` with the test value `value`.
     ///
     /// # Arguments
     /// * `param_name` - A string slice that holds the name of the parameter to test
-    /// * `value` - A LookupRhs which holds the value to check equality for, can be a boolean, a
+    /// * `test` - The type of test to run, ==, !=, <, <=, > or >=
+    /// * `value` - A Literal which holds the value to check equality for, can be a boolean, a
     ///             string or a number
     ///
     /// # Return
     /// * bool - true if the current packet has a parameter called `param_name` and its value
-    ///          is equal to the LookupRhs.
+    ///          passes the specified test with the input test `value`.
     fn test_parameter(&self, param_name: &str, test: &Test, value: &Literal) -> bool {
         if let Some(json_value) = self.get_parameter(param_name) {
             match test {

--- a/src/query/query_parse.rs
+++ b/src/query/query_parse.rs
@@ -172,9 +172,9 @@ mod tests {
         }
 
         let e = parse_query("latest(\"123\")").unwrap_err();
-        assert!(matches!(e, QueryError::ParseError(..)));
+        assert!(matches!(e, QueryError::ParseError(_)));
         let e = parse_query("123").unwrap_err();
-        assert!(matches!(e, QueryError::ParseError(..)));
+        assert!(matches!(e, QueryError::ParseError(_)));
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let res = parse_query("parameter:x == False").unwrap();
         assert!(matches!(res, QueryNode::Test(Test::Equal, Lookup::Parameter("x"), Literal::Bool(false))));
         let e = parse_query("parameter:x == T").unwrap_err();
-        assert!(matches!(e, QueryError::ParseError(..)));
+        assert!(matches!(e, QueryError::ParseError(_)));
         assert!(e
             .to_string()
             .contains("expected lookupValue"));
@@ -243,7 +243,7 @@ mod tests {
         assert!(matches!(res, QueryNode::Test(Test::GreaterThanOrEqual, Lookup::Id, Literal::String("123"))));
 
         let e = parse_query("name =! \"123\"").unwrap_err();
-        assert!(matches!(e, QueryError::ParseError(..)));
+        assert!(matches!(e, QueryError::ParseError(_)));
         assert!(e
             .to_string()
             .contains("Encountered unknown infix operator: =!"));

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -1,19 +1,24 @@
 #[derive(Debug, PartialEq)]
-pub enum LookupLhs<'a> {
+pub enum Lookup<'a> {
     Name,
     Id,
     Parameter(&'a str)
 }
 
 #[derive(Debug)]
-pub enum LookupRhs<'a> {
+pub enum Literal<'a> {
     Bool(bool),
     String(&'a str),
     Number(f64)
 }
 
 #[derive(Debug)]
+pub enum Test {
+    Equal
+}
+
+#[derive(Debug)]
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
-    Lookup(LookupLhs<'a>, LookupRhs<'a>),
+    Test(Test, Lookup<'a>, Literal<'a>),
 }

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -46,28 +46,28 @@ mod tests {
 
     #[test]
     fn literal_partial_eq_ord_works() {
-        let lit_1 = Literal::Number(10f64);
-        let lit_2 = Literal::Number(10f64);
-        let lit_3 = Literal::Number(11.1);
-        let lit_4 = Literal::Bool(true);
-        let lit_5 = Literal::Bool(false);
-        let lit_6 = Literal::String("test");
-        let lit_7 = Literal::String("test2");
+        let lit_num1 = Literal::Number(10f64);
+        let lit_num2 = Literal::Number(10f64);
+        let lit_num3 = Literal::Number(11.1);
+        let lit_bool1 = Literal::Bool(true);
+        let lit_bool2 = Literal::Bool(false);
+        let lit_str1 = Literal::String("test");
+        let lit_str2 = Literal::String("test2");
 
-        assert_eq!(lit_1, lit_2);
-        assert_ne!(lit_2, lit_3);
-        assert_ne!(lit_3, lit_4);
-        assert_ne!(lit_4, lit_5);
-        assert_ne!(lit_5, lit_6);
-        assert_ne!(lit_6, lit_7);
+        assert_eq!(lit_num1, lit_num2);
+        assert_ne!(lit_num2, lit_num3);
+        assert_ne!(lit_num3, lit_bool1);
+        assert_ne!(lit_bool1, lit_bool2);
+        assert_ne!(lit_bool2, lit_str1);
+        assert_ne!(lit_str1, lit_str2);
 
-        assert!(lit_1 < lit_3);
-        assert_eq!(lit_3.partial_cmp(&lit_1), Some(Ordering::Greater));
-        assert!(lit_1 <= lit_2);
-        assert!(lit_3 > lit_1);
+        assert!(lit_num1 < lit_num3);
+        assert_eq!(lit_num3.partial_cmp(&lit_num1), Some(Ordering::Greater));
+        assert!(lit_num1 <= lit_num2);
+        assert!(lit_num3 > lit_num1);
 
         // Is undefined on non-number variants
-        assert!(lit_4.partial_cmp(&lit_5).is_none());
-        assert!(lit_5.partial_cmp(&lit_4).is_none());
+        assert!(lit_bool1.partial_cmp(&lit_bool2).is_none());
+        assert!(lit_bool2.partial_cmp(&lit_bool1).is_none());
     }
 }

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -14,7 +14,12 @@ pub enum Literal<'a> {
 
 #[derive(Debug)]
 pub enum Test {
-    Equal
+    Equal,
+    NotEqual,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
 }
 
 #[derive(Debug)]

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 #[derive(Debug, PartialEq)]
 pub enum Lookup<'a> {
     Name,
@@ -5,11 +7,20 @@ pub enum Lookup<'a> {
     Parameter(&'a str)
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum Literal<'a> {
     Bool(bool),
     String(&'a str),
     Number(f64)
+}
+
+impl<'a> PartialOrd for Literal<'a> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (Literal::Number(num_1), Literal::Number(num_2)) => num_1.partial_cmp(num_2),
+            (_, _) => None
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -26,4 +37,37 @@ pub enum Test {
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
     Test(Test, Lookup<'a>, Literal<'a>),
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_partial_eq_ord_works() {
+        let lit_1 = Literal::Number(10f64);
+        let lit_2 = Literal::Number(10f64);
+        let lit_3 = Literal::Number(11.1);
+        let lit_4 = Literal::Bool(true);
+        let lit_5 = Literal::Bool(false);
+        let lit_6 = Literal::String("test");
+        let lit_7 = Literal::String("test2");
+
+        assert_eq!(lit_1, lit_2);
+        assert_ne!(lit_2, lit_3);
+        assert_ne!(lit_3, lit_4);
+        assert_ne!(lit_4, lit_5);
+        assert_ne!(lit_5, lit_6);
+        assert_ne!(lit_6, lit_7);
+
+        assert!(lit_1 < lit_3);
+        assert_eq!(lit_3.partial_cmp(&lit_1), Some(Ordering::Greater));
+        assert!(lit_1 <= lit_2);
+        assert!(lit_3 > lit_1);
+
+        // Is undefined on non-number variants
+        assert!(lit_4.partial_cmp(&lit_5).is_none());
+        assert!(lit_5.partial_cmp(&lit_4).is_none());
+    }
 }

--- a/src/query/test_utils_query.rs
+++ b/src/query/test_utils_query.rs
@@ -2,11 +2,11 @@
 pub mod tests {
     use crate::query::query_types::*;
 
-    pub fn assert_query_node_lookup_number_eq(node: QueryNode, lookup: LookupLhs, test: f64) {
-        if let QueryNode::Lookup(lhs, rhs) = node {
+    pub fn assert_query_node_lookup_number_eq(node: QueryNode, lookup: Lookup, test: f64) {
+        if let QueryNode::Test(Test::Equal, lhs, rhs) = node {
             assert_eq!(lhs, lookup);
             match rhs {
-                LookupRhs::Number(value) => assert_eq!(value, test),
+                Literal::Number(value) => assert_eq!(value, test),
                 _ => panic!("Query parse rhs should have returned a Float")
             }
         } else {

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -3,6 +3,11 @@ use outpack::query::QueryError;
 use predicates::prelude::*;
 use std::process::Command;
 
+pub fn test_query(root: &str, query: &str, result: &str) {
+    let packets = outpack::query::run_query(root, query).unwrap();
+    assert_eq!(packets, result);
+}
+
 #[test]
 fn prints_usage_if_args_invalid() {
     let mut cmd = Command::cargo_bin("outpack_query").unwrap();
@@ -12,8 +17,7 @@ fn prints_usage_if_args_invalid() {
 #[test]
 fn locates_latest_packet() {
     let root_path = "tests/example";
-    let packets = outpack::query::run_query(root_path, "latest").unwrap();
-    assert_eq!(packets, "20180818-164043-7cdcde4b");
+    test_query(root_path, "latest", "20180818-164043-7cdcde4b");
 }
 
 #[test]
@@ -35,33 +39,19 @@ fn eval_error_can_be_displayed() {
 #[test]
 fn can_get_packet_by_id() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "id == \"20170818-164847-7574883b\"").unwrap();
-    assert_eq!(packets, "20170818-164847-7574883b");
-    let packets =
-        outpack::query::run_query(root_path, "id == \"20170818-164830-33e0ab01\"").unwrap();
-    assert_eq!(packets, "20170818-164830-33e0ab01");
-    let packets = outpack::query::run_query(root_path, "\"123\"").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "id == \"20170818-164847-7574883b\"", "20170818-164847-7574883b");
+    test_query(root_path, "id == \"20170818-164830-33e0ab01\"", "20170818-164830-33e0ab01");
+    test_query(root_path, "\"123\"", "Found no packets");
 }
 
 #[test]
 fn can_get_packet_by_name() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "name == \"modup-201707-queries1\"").unwrap();
-    assert_eq!(
-        packets,
-        "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180818-164043-7cdcde4b"
-    );
-    let packets =
-        outpack::query::run_query(root_path, "name == 'modup-201707-queries1'").unwrap();
-    assert_eq!(
-        packets,
-        "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180818-164043-7cdcde4b"
-    );
-    let packets = outpack::query::run_query(root_path, "name == \"notathing\"").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "name == \"modup-201707-queries1\"",
+               "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180818-164043-7cdcde4b");
+    test_query(root_path, "name == 'modup-201707-queries1'",
+               "20170818-164830-33e0ab01\n20170818-164847-7574883b\n20180818-164043-7cdcde4b");
+    test_query(root_path, "name == \"notathing\"", "Found no packets");
     let e = outpack::query::run_query(root_path, "name == invalid").unwrap_err();
     assert!(matches!(e, QueryError::ParseError(..)));
     assert!(e.to_string().contains("expected lookupValue"));
@@ -70,9 +60,7 @@ fn can_get_packet_by_name() {
 #[test]
 fn can_get_latest_of_lookup() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "latest(name == \"modup-201707-queries1\")").unwrap();
-    assert_eq!(packets, "20180818-164043-7cdcde4b");
+    test_query(root_path, "latest(name == \"modup-201707-queries1\")", "20180818-164043-7cdcde4b");
 }
 
 #[test]
@@ -82,36 +70,20 @@ fn can_get_packet_by_parameter() {
         outpack::query::run_query(root_path, "parameter:disease == \"YF\"").unwrap();
     assert_eq!(packets, "20170818-164830-33e0ab01\n20180220-095832-16a4bbed\n\
     20180818-164043-7cdcde4b");
-    let packets =
-        outpack::query::run_query(root_path, "latest(parameter:disease == \"YF\")").unwrap();
-    assert_eq!(packets, "20180818-164043-7cdcde4b");
-    let packets =
-        outpack::query::run_query(root_path, "latest(parameter:unknown == \"YF\")").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "latest(parameter:disease == \"YF\")", "20180818-164043-7cdcde4b");
+    test_query(root_path, "latest(parameter:unknown == \"YF\")", "Found no packets");
 }
 
 
 #[test]
 fn can_get_packet_by_boolean_parameter() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == TRUE").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == true").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == false").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == \"true\"").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == 1").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:pull_data == 0").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "parameter:pull_data == TRUE", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:pull_data == true", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:pull_data == false", "Found no packets");
+    test_query(root_path, "parameter:pull_data == \"true\"", "Found no packets");
+    test_query(root_path, "parameter:pull_data == 1", "Found no packets");
+    test_query(root_path, "parameter:pull_data == 0", "Found no packets");
     let e =
         outpack::query::run_query(root_path, "parameter:pull_data == T").unwrap_err();
     assert!(matches!(e, QueryError::ParseError(..)));
@@ -121,76 +93,36 @@ fn can_get_packet_by_boolean_parameter() {
 #[test]
 fn can_get_packet_by_numeric_parameter() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance == 0.001").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance == 1e-3").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance == 0.1e-2").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance == 0.002").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:size == 10").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:size == 10.0").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:size == 1e1").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:size == 1e+1").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:size == \"10\"").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "parameter:tolerance == 0.001", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance == 1e-3", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance == 0.1e-2", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance == 0.002", "Found no packets");
+    test_query(root_path, "parameter:size == 10", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:size == 10.0", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:size == 1e1", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:size == 1e+1", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:size == \"10\"", "Found no packets");
 }
 
 #[test]
 fn no_packets_returned_incompatible_types() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "id == 12345").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "id == true").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "name == true").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "id == 12345", "Found no packets");
+    test_query(root_path, "id == true", "Found no packets");
+    test_query(root_path, "name == true", "Found no packets");
 }
 
 
 #[test]
 fn can_get_packet_other_comparisons() {
     let root_path = "tests/example";
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance < 0.002").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance <= 0.002").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance > 0.1e-5").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance >= 0.1e-2").unwrap();
-    assert_eq!(packets, "20180220-095832-16a4bbed");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:tolerance < 0.1e-2").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "parameter:tolerance < 0.002", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance <= 0.002", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance > 0.1e-5", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance >= 0.1e-2", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance < 0.1e-2", "Found no packets");
 
-    let packets =
-        outpack::query::run_query(root_path, "parameter:disease < \"AB\"").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:disease > \"AB\"").unwrap();
-    assert_eq!(packets, "Found no packets");
-    let packets =
-        outpack::query::run_query(root_path, "parameter:disease <= \"YF\"").unwrap();
-    assert_eq!(packets, "Found no packets");
+    test_query(root_path, "parameter:disease < \"AB\"", "Found no packets");
+    test_query(root_path, "parameter:disease > \"AB\"", "Found no packets");
+    test_query(root_path, "parameter:disease <= \"YF\"", "Found no packets");
 }

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -163,3 +163,34 @@ fn no_packets_returned_incompatible_types() {
         outpack::query::run_query(root_path, "name == true").unwrap();
     assert_eq!(packets, "Found no packets");
 }
+
+
+#[test]
+fn can_get_packet_other_comparisons() {
+    let root_path = "tests/example";
+    let packets =
+        outpack::query::run_query(root_path, "parameter:tolerance < 0.002").unwrap();
+    assert_eq!(packets, "20180220-095832-16a4bbed");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:tolerance <= 0.002").unwrap();
+    assert_eq!(packets, "20180220-095832-16a4bbed");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:tolerance > 0.1e-5").unwrap();
+    assert_eq!(packets, "20180220-095832-16a4bbed");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:tolerance >= 0.1e-2").unwrap();
+    assert_eq!(packets, "20180220-095832-16a4bbed");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:tolerance < 0.1e-2").unwrap();
+    assert_eq!(packets, "Found no packets");
+
+    let packets =
+        outpack::query::run_query(root_path, "parameter:disease < \"AB\"").unwrap();
+    assert_eq!(packets, "Found no packets");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:disease > \"AB\"").unwrap();
+    assert_eq!(packets, "Found no packets");
+    let packets =
+        outpack::query::run_query(root_path, "parameter:disease <= \"YF\"").unwrap();
+    assert_eq!(packets, "Found no packets");
+}


### PR DESCRIPTION
This was a little bit of a fiddly one and there is some churn here but I think the end result isn't too bad actually!

This PR will add support to the querying language to run use additional tests `!=`, `<`, `>`, `<=`, `>=`. With this PR you should be able to run queries like
* `id != "123"`
* `name != "my_report"`
* `parameter:x > 2`
* `parameter:x >= 0.002`
* `parameter:y < 5`
* `parameter:y <= 5`

If you use a bool or a string on any of the ordering queries `<`, `<=`, `>`, `>=` this will return return no matches. We don't do any type coersion. This agrees with current verison in the R impl.