### PR TITLE
mrc-4551: Add function to assert only a single packet returned from query

### DIFF
--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -15,10 +15,12 @@ expr = _{ prefix? ~ (brackets | singleVariableFunc | noVariableFunc | infixExpre
 
 brackets = { "(" ~ body ~ ")" }
 
-noVariableFunc     =  { funcNames ~ "()" }
-singleVariableFunc =  { funcNames ~ "(" ~ body ~ ")" }
-funcNames          = _{ latest }
-latest             =  { "latest" }
+noVariableFunc          =  { noVariableFuncNames ~ "()" }
+singleVariableFunc      =  { singleVariableFuncNames ~ "(" ~ body ~ ")" }
+noVariableFuncNames     =  _{ latest }
+singleVariableFuncNames =  _{ latest | single }
+latest                  =  { "latest" }
+single                  =  { "single" }
 
 infixExpression = { lookup ~ infixFunction ~ lookupValue }
 infixFunction   = @{ ("=" | "!" | "<" | ">"){1,2} }

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -42,6 +42,7 @@ pub enum Operator {
 #[derive(Debug)]
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
+    Single(Box<QueryNode<'a>>),
     Test(Test, Lookup<'a>, Literal<'a>),
     Negation(Box<QueryNode<'a>>),
     Brackets(Box<QueryNode<'a>>),

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -177,3 +177,14 @@ fn query_functions_can_be_nested() {
     test_query(root_path, r#"latest(id == "20170818-164847-7574883b" || id == "20180220-095832-16a4bbed")"#,
                "20180220-095832-16a4bbed");
 }
+
+#[test]
+fn query_can_assert_single_return() {
+    let root_path = "tests/example";
+    test_query(root_path, "single(parameter:pull_data == TRUE)",
+               "20180220-095832-16a4bbed");
+    let e =
+        outpack::query::run_query(root_path, "single(parameter:pull_data == false)").unwrap_err();
+    assert!(matches!(e, QueryError::EvalError(..)));
+    assert!(e.to_string().contains("Query found 0 packets, but expected exactly one"));
+}


### PR DESCRIPTION
This PR will add support into the querying for the `single` function which asserts that the inner query contains one and only one packet.