### PR TITLE
mrc-4531: Enable comparison operators in any order

### DIFF
--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -15,10 +15,12 @@ expr = _{ prefix? ~ (brackets | singleVariableFunc | noVariableFunc | infixExpre
 
 brackets = { "(" ~ body ~ ")" }
 
-noVariableFunc     =  { funcNames ~ "()" }
-singleVariableFunc =  { funcNames ~ "(" ~ body ~ ")" }
-funcNames          = _{ latest }
-latest             =  { "latest" }
+noVariableFunc          =  { noVariableFuncNames ~ "()" }
+singleVariableFunc      =  { singleVariableFuncNames ~ "(" ~ body ~ ")" }
+noVariableFuncNames     =  _{ latest }
+singleVariableFuncNames =  _{ latest | single }
+latest                  =  { "latest" }
+single                  =  { "single" }
 
 infixExpression = { lookup ~ infixFunction ~ lookupValue }
 infixFunction   = @{ ("=" | "!" | "<" | ">"){1,2} }

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -22,7 +22,7 @@ singleVariableFuncNames =  _{ latest | single }
 latest                  =  { "latest" }
 single                  =  { "single" }
 
-infixExpression = { lookup ~ infixFunction ~ lookupValue }
+infixExpression = { lookup ~ infixFunction ~ lookupValue | lookupValue ~ infixFunction ~ lookup }
 infixFunction   = @{ ("=" | "!" | "<" | ">"){1,2} }
 
 lookup          = { lookupId | lookupName | lookupParam }

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -42,6 +42,7 @@ pub enum Operator {
 #[derive(Debug)]
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
+    Single(Box<QueryNode<'a>>),
     Test(Test, Lookup<'a>, Literal<'a>),
     Negation(Box<QueryNode<'a>>),
     Brackets(Box<QueryNode<'a>>),

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -177,3 +177,14 @@ fn query_functions_can_be_nested() {
     test_query(root_path, r#"latest(id == "20170818-164847-7574883b" || id == "20180220-095832-16a4bbed")"#,
                "20180220-095832-16a4bbed");
 }
+
+#[test]
+fn query_can_assert_single_return() {
+    let root_path = "tests/example";
+    test_query(root_path, "single(parameter:pull_data == TRUE)",
+               "20180220-095832-16a4bbed");
+    let e =
+        outpack::query::run_query(root_path, "single(parameter:pull_data == false)").unwrap_err();
+    assert!(matches!(e, QueryError::EvalError(..)));
+    assert!(e.to_string().contains("Query found 0 packets, but expected exactly one"));
+}

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -188,3 +188,12 @@ fn query_can_assert_single_return() {
     assert!(matches!(e, QueryError::EvalError(..)));
     assert!(e.to_string().contains("Query found 0 packets, but expected exactly one"));
 }
+
+#[test]
+fn comparisons_work_in_any_order() {
+    let root_path = "tests/example";
+    test_query(root_path, "parameter:pull_data == TRUE", "20180220-095832-16a4bbed");
+    test_query(root_path, "TRUE == parameter:pull_data", "20180220-095832-16a4bbed");
+    test_query(root_path, "parameter:tolerance < 0.002", "20180220-095832-16a4bbed");
+    test_query(root_path, "0.002 > parameter:tolerance", "20180220-095832-16a4bbed");
+}


### PR DESCRIPTION
This builds on #40 and should be merged after that

After this PR you will be able to use comparison operators in any order i.e.
* `parameter:iso3 == "MWI"` or `"MWI" == parameter:iso3`
* `parameter:nmax < 2` or `2 > parameter:nmax`