### PR TITLE
Remove the need for a preparsing step.

### DIFF
--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -10,7 +10,7 @@ extern crate pest;
 use crate::index::get_packet_index;
 use crate::query::query_eval::eval_query;
 use crate::query::query_format::format_query_result;
-use crate::query::query_parse::{parse_query, preparse_query, Rule};
+use crate::query::query_parse::{parse_query, Rule};
 use std::fmt;
 
 pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
@@ -23,8 +23,7 @@ pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
             )))
         }
     };
-    let preparsed = preparse_query(query);
-    let parsed = parse_query(&preparsed)?;
+    let parsed = parse_query(query)?;
     let result = eval_query(&index, parsed);
     format_query_result(result)
 }

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -1,8 +1,11 @@
 // See the pest editor https://pest.rs/#editor for an easy way to see how
 // inputs are parsed by this grammar
 
-query = { SOI ~ body ~ EOI }
+query = { SOI ~ toplevel ~ EOI }
+toplevel = _{ body | shortformLatest | shortformId }
 body  = { expr ~ (booleanOperator ~ expr)* }
+shortformLatest = { "latest" }
+shortformId = { string }
 
 prefix   = _{ negation }
 negation = { "!" }


### PR DESCRIPTION
The query language allows for a few short-form syntaxes that are only valid at the toplevel, not within complex expressions. Previously these were handled through a "preparse" step that would match on the string with regexes and convert it into a valid expression.

This commit replaces the preparsing step with a few new rules in the PEG-based parser. This makes the parser more consistent and should allow for better errorsi by keeping the spans accurate.

This also solves an inconvenience of the parser API. The nodes generated by the parser borrow from its input string, and are therefore bound by that lifetime. Previously that "input string" was actually the preprocessed query, rather than the original query. The output nodes would therefore have to borrow from that temporary string which made it impossible to write a high-level `parse<'a>(&'a str) -> QueryNode<'a>`. Instead the user of the API had to call the preparse and parse steps explicitly.