### PR TITLE
Add parsing for `this:` and `environment:` in queries.

### DIFF
--- a/src/bin/outpack_query.rs
+++ b/src/bin/outpack_query.rs
@@ -1,18 +1,27 @@
 extern crate core;
 
 use getopts::Options;
-use std::{env, process};
+use std::{env, process::ExitCode};
+
+use outpack::query::QueryError;
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} [options]", program);
     print!("{}", opts.usage(&brief));
 }
 
-fn parse_args(args: &[String]) -> (String, String) {
+enum Args {
+    Parse { query: String },
+    Eval { query: String, root: String },
+}
+
+fn parse_args(args: &[String]) -> Args {
     let program = args[0].clone();
     let mut opts = Options::new();
     opts.reqopt("q", "query", "outpack query (required)", "latest");
-    opts.reqopt("r", "root", "outpack root path (required)", ".");
+    opts.optopt("r", "root", "outpack root path", ".");
+    opts.optflag("", "parse-only", "parse the query without running it");
+
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
@@ -20,20 +29,48 @@ fn parse_args(args: &[String]) -> (String, String) {
             panic!("{}", f.to_string())
         }
     };
-    (matches.opt_str("r").unwrap(), matches.opt_str("q").unwrap())
+
+    if matches.opt_present("parse-only") && matches.opt_present("root") {
+        panic!("--parse-only and --root are mutually exclusive");
+    }
+    if !matches.opt_present("parse-only") && !matches.opt_present("root") {
+        panic!("Either --parse-only or --root are required");
+    }
+
+    if matches.opt_present("parse-only") {
+        Args::Parse {
+            query: matches.opt_str("q").unwrap(),
+        }
+    } else {
+        Args::Eval {
+            query: matches.opt_str("q").unwrap(),
+            root: matches.opt_str("r").unwrap(),
+        }
+    }
 }
 
-fn main() {
+fn run() -> Result<(), QueryError> {
     let args = env::args().collect::<Vec<_>>();
-    let (root, query) = parse_args(&args);
-    let result = outpack::query::run_query(&root, &query);
-    match result {
-        Ok(res) => {
-            println!("{}", res)
+    match parse_args(&args) {
+        Args::Eval { query, root } => {
+            let result = outpack::query::run_query(&root, &query)?;
+            println!("{}", result);
         }
-        Err(e) => {
-            eprintln!("{}", e);
-            process::exit(1);
+        Args::Parse { query } => {
+            let result = outpack::query::parse_query(&query)?;
+            println!("{:?}", result);
+        }
+    };
+
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(err) => {
+            eprintln!("{}", err);
+            ExitCode::FAILURE
         }
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -10,8 +10,10 @@ extern crate pest;
 use crate::index::get_packet_index;
 use crate::query::query_eval::eval_query;
 use crate::query::query_format::format_query_result;
-use crate::query::query_parse::{parse_query, Rule};
+use crate::query::query_parse::Rule;
 use std::fmt;
+
+pub use crate::query::query_parse::parse_query;
 
 pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
     let index = match get_packet_index(root) {

--- a/src/query/query.pest
+++ b/src/query/query.pest
@@ -28,13 +28,17 @@ single                  =  { "single" }
 infixExpression = { testValue ~ infixFunction ~ testValue }
 infixFunction   = @{ ("=" | "!" | "<" | ">"){1,2} }
 
-testValue       = _{ lookup | literal }
-lookup          = { lookupId | lookupName | lookupParam }
-lookupId        = { "id" }
-lookupName      = { "name" }
-lookupParam     = { "parameter:" ~ lookupParamName }
-lookupParamName = @{ (ASCII_ALPHANUMERIC | "_" )+ }
-literal     = { string | boolean | number }
+testValue         = _{ lookup | literal}
+lookup            = { lookupPacket | lookupThis | lookupEnvironment  }
+lookupPacket      = { lookupPacketId | lookupPacketName | lookupPacketParam }
+lookupPacketId    = { "id" }
+lookupPacketName  = { "name" }
+lookupPacketParam = { "parameter:" ~ identifier }
+lookupThis        = { "this:" ~ identifier }
+lookupEnvironment = { "environment:" ~ identifier }
+literal           = { string | boolean | number }
+
+identifier = @{ (ASCII_ALPHANUMERIC | "_" )+ }
 
 number = @{
     ("-" | "+")?

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -1,10 +1,17 @@
 use std::cmp::Ordering;
 
 #[derive(Debug, PartialEq)]
-pub enum Lookup<'a> {
+pub enum PacketLookup<'a> {
     Name,
     Id,
     Parameter(&'a str),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Lookup<'a> {
+    Packet(PacketLookup<'a>),
+    This(&'a str),
+    Environment(&'a str),
 }
 
 #[derive(Debug, PartialEq, Clone)]


### PR DESCRIPTION
These are not currently supported by the evaluation, since they only make sense when used from within a report script.

The outpack_query has a new `--parse-only` flag that can be used to see the result of the parser.