### PR TITLE
Add python bindings for the query parser.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -12,18 +12,27 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest}
-          - {os: macos-latest}
-          - {os: windows-latest}
+          - {os: ubuntu-latest,  py: '3.8'}
+          - {os: ubuntu-latest,  py: '3.9'}
+          - {os: ubuntu-latest,  py: '3.10'}
+          - {os: ubuntu-latest,  py: '3.11'}
+          - {os: macos-latest,   py: '3.11'}
+          - {os: windows-latest, py: '3.11'}
 
-    name: ${{matrix.config.os }}
+    name: ${{matrix.config.os }} (${{ matrix.config.py }})
     runs-on: ${{ matrix.config.os }}
+
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: clippy
+      - name: Set up Python ${{ matrix.config.py }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.config.py }}
       - name: Lint
         run: cargo clippy -- -D warnings
       - name: Format check
@@ -32,3 +41,12 @@ jobs:
         run: cargo check --release --all-features
       - name: Test
         run: cargo test
+
+      - name: Install python dependencies
+        run: |
+          python -m pip install --upgrade pip build
+          pip install hatch
+
+      - name: Run Python tests
+        run: |
+          hatch run test

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 montagu-reports
 tests/example/.outpack/index
 example.tar
+__pycache__
+*.so

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ montagu-reports
 tests/example/.outpack/index
 example.tar
 __pycache__
-*.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+/dist
 .idea
 montagu-reports
 tests/example/.outpack/index

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "7b2d0f03b3640e3a630367e40c468cb7f309529c708ed1d88597047b0e7c6ef7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -338,7 +338,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -448,7 +448,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -850,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "inlinable_string"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,6 +1035,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1230,6 +1245,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "predicates 2.1.5",
+ "pyo3",
  "regex",
  "rocket",
  "serde",
@@ -1293,7 +1309,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1332,7 +1348,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1423,9 +1439,70 @@ checksum = "606c4ba35817e2922a308af55ad51bab3645b59eae5c570d4a6cf07e36bd493b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
  "version_check",
  "yansi",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8453b658fe480c3e70c8ed4e3d3ec33eb74988bd186561b0cc66b85c3bc4b"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96fe70b176a89cff78f2fa7b3c930081e163d5379b4dcdf993e3ae29ca662e5"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214929900fd25e6604661ed9cf349727c8920d47deff196c4e28165a6ef2a96b"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac53072f717aa1bfa4db832b39de8c875b7c7af4f4a6fe93cdbf9264cf8383b"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774b5a8282bd4f25f803b1f0d945120be959a36c72e08e7cd031c792fdfd424"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1539,7 +1616,7 @@ checksum = "8d2275aab483050ab2a7364c1a46604865ee7d6906684e08db0f090acf74f9e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1668,7 +1745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.23",
+ "syn 2.0.32",
  "unicode-xid",
 ]
 
@@ -1767,29 +1844,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1925,9 +2002,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.23"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fb7d6d8281a51045d62b8eb3a7d1ce347b76f312af50cd3dc0af39c87c1737"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1944,6 +2021,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c39fd04924ca3a864207c66fc2cd7d22d7c016007f9ce846cbb9326331930a"
 
 [[package]]
 name = "tempdir"
@@ -1992,7 +2075,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2074,7 +2157,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2162,7 +2245,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2269,6 +2352,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,7 +2447,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -2392,7 +2481,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.23",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "outpack"
 version = "0.2.0"
 edition = "2021"
 rust-version = "1.70"
-include = ["schema/*"]
 
 [lib]
 crate-type = ["rlib", "cdylib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 name = "outpack"
 version = "0.2.0"
 edition = "2021"
-include = ["schema/*"]
 rust-version = "1.70"
+include = ["schema/*"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 rocket = { version = "0.5.0-rc.2", features = ["json"] }
@@ -25,6 +26,7 @@ tempfile = "3.6.0"
 clap = { version = "4.4.8", features = ["derive"] }
 anyhow = "1.0.75"
 thiserror = "1.0.50"
+pyo3 = { version = "0.20.0", features = ["extension-module"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.6"
@@ -33,3 +35,6 @@ jsonschema = "0.16.1"
 url = "2.3.1"
 tempdir = "0.3.7"
 tar = "0.4.38"
+
+[features]
+python = [ "dep:pyo3" ]

--- a/README.md
+++ b/README.md
@@ -292,6 +292,18 @@ The metadata should be written directly to the request body.
 }
 ```
 
+## Python bindings
+
+This crate provides Python bindings for its query parser. The bindings can be installed using `pip install .`.
+
+### Local development
+
+```
+hatch run python  # Start a Python interpreter with the bindings installed
+hatch run test    # Run the bindings test-suite
+hatch run develop # Rebuild the bindings. Necessary whenever changes to Rust code is made.
+```
+
 ## License
 
 MIT © Imperial College of Science, Technology and Medicine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "outpack_query_parser"
+
+[build-system]
+requires = ["maturin>=1.0,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+features = ["python"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,13 @@ build-backend = "maturin"
 
 [tool.maturin]
 features = ["python"]
+
+[tool.hatch.version]
+path = "Cargo.toml"
+
+[tool.hatch.envs.default]
+dependencies = [ "pytest" ]
+
+[tool.hatch.envs.default.scripts]
+test = "pytest {args:tests/python}"
+develop = "maturin develop"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,3 @@ mod responses;
 mod store;
 mod test_utils;
 mod utils;
-
-#[macro_use]
-extern crate pest_derive;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -5,14 +5,16 @@ mod query_types;
 
 mod test_utils_query;
 
-extern crate pest;
+#[cfg(feature = "python")]
+mod python;
 
 use crate::index::get_packet_index;
 use crate::query::query_eval::eval_query;
 use crate::query::query_format::format_query_result;
+pub use crate::query::query_parse::parse_query;
 use crate::query::query_parse::Rule;
 
-pub use crate::query::query_parse::parse_query;
+use thiserror::Error;
 
 pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
     let index = match get_packet_index(root) {
@@ -29,15 +31,26 @@ pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
     format_query_result(result)
 }
 
-#[derive(thiserror::Error, Debug, Clone)]
-// Results with QueryError are at least as large as the QueryError variant. The compiler
-// will need to reserve that much memory every time it is used. We want to keep this as
-// small as possible so Box the large error body to force it onto the heap.
+// pest's error type is quite large, which would consume a lot of stack space and require moving
+// data around, even in the happy path when an Ok is returned. We want to keep this as small as
+// possible so Box the large error body to force it onto the heap. The heap memory allocation cost
+// is only incurred when an actual error is returned.
 // See https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
+#[derive(Error, Debug, Clone)]
+#[error(transparent)]
+pub struct ParseError(Box<pest::error::Error<Rule>>);
+
+#[derive(Error, Debug, Clone)]
 pub enum QueryError {
     #[error("Failed to parse query\n{0}")]
-    ParseError(Box<pest::error::Error<Rule>>),
+    ParseError(#[from] ParseError),
 
     #[error("Failed to evaluate query\n{0}")]
     EvalError(String),
+}
+
+impl From<pest::error::Error<Rule>> for ParseError {
+    fn from(err: pest::error::Error<Rule>) -> ParseError {
+        ParseError(Box::new(err))
+    }
 }

--- a/src/query/python.rs
+++ b/src/query/python.rs
@@ -1,0 +1,310 @@
+//! Python bindings for the Outpack query parser.
+//!
+//! This file exports a Python module named `outpack_query_parser` which can be used from a Python
+//! application to parse an Outpack query.
+//!
+//! # Example:
+//! ```py
+//! from outpack_query_parser import parse_query
+//! print(parse_query("name == 'foo'"))
+//! # Prints:
+//! # Test(operator=Operator.Equal, lhs=LookupName(), rhs=Literal(value='foo'))
+//! ```
+//!
+//! Most of the glue is handled by the PyO3 crate. Calling into the actual parser is trivially done
+//! by the [`parse_query`] function. Most of the module's code is responsible for setting a
+//! parallel AST type hiearchy and implementing conversion from the query_types module to these
+//! types.
+
+use crate::query::query_types as ast;
+use crate::query::ParseError;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::types::{PyNone, PyString, PyTuple};
+
+#[pyfunction]
+fn parse_query<'a>(input: &'a str) -> Result<ast::QueryNode<'a>, ParseError> {
+    crate::query::parse_query(input)
+}
+
+#[pymodule]
+fn outpack_query_parser(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(parse_query, m)?)?;
+    m.add_class::<Latest>()?;
+    m.add_class::<Single>()?;
+    m.add_class::<Test>()?;
+    m.add_class::<Negation>()?;
+    m.add_class::<Brackets>()?;
+    m.add_class::<BooleanOperator>()?;
+    m.add_class::<Operator>()?;
+    m.add_class::<Literal>()?;
+    m.add_class::<LookupThis>()?;
+    m.add_class::<LookupParameter>()?;
+    m.add_class::<LookupId>()?;
+    m.add_class::<LookupName>()?;
+    Ok(())
+}
+
+/// Concatenate string literals together, interspersing a separator between each element.
+///
+/// The first argument is the separator. The elements to concatenate are passed as the subsequent
+/// elements.
+///
+/// ```ignore(https://github.com/rust-lang/rust/issues/97030)
+/// assert_eq!(intersperse!(", ", "a", "b", "c"), "a, b, c");
+/// ```
+macro_rules! intersperse {
+    ($sep:expr  $(,)?) => { "" };
+    ($sep:expr, $head:expr $(,)?) => { $head };
+    ($sep:expr, $head:expr, $($tail:expr),+ $(,)?) => {
+        concat!($head, $sep, intersperse!($sep, $($tail,)+))
+    };
+}
+
+/// Define a Python class with dataclass-like semantics.
+///
+/// The class will have a constructor, __repr__ and __eq__ methods and getters for each field.
+///
+/// Fields must be Python values, wrapped in a `Py<T>`, such as `Py<PyAny>`, `Py<PyString>` or
+/// `Py<C>` where `C` is another struct with a `#[pyclass]` annotation.
+macro_rules! dataclass {
+    () => {};
+
+    (struct $name:ident ; $($rest:tt)* ) => {
+        #[pyclass(frozen)]
+        struct $name;
+
+        dataclass_impl!(struct $name { });
+        dataclass!($($rest)*);
+    };
+
+    (struct $name:ident { $($field_name:ident : $field_type:ty),* $(,)? } $($rest:tt)* ) => {
+        #[pyclass(frozen, get_all)]
+        struct $name {
+            $($field_name: $field_type),*
+        }
+        dataclass_impl!(struct $name { $($field_name: $field_type),* });
+        dataclass!($($rest)*);
+    };
+}
+
+macro_rules! dataclass_impl {
+    (struct $name:ident { $($field_name:ident : $field_type:ty),* $(,)? } ) => {
+        #[pymethods]
+        impl $name {
+            #[new]
+            fn new($($field_name: $field_type),*) -> Self {
+                Self { $($field_name,)* }
+            }
+
+            fn __repr__(&self, #[allow(unused)] py: Python<'_>) -> PyResult<String> {
+                Ok(format!(concat!(
+                    stringify!($name),
+                    "(",
+                    intersperse!(", ", $(concat!(stringify!($field_name), "={}"),)*),
+                    ")"), $(self.$field_name.as_ref(py).repr()?),*))
+            }
+
+            fn __eq__(&self, py: Python<'_>, other: PyObject) -> PyResult<bool> {
+                if let Ok(other) = other.downcast::<PyCell<Self>>(py) {
+                    #[allow(unused)]
+                    let other_inner = other.get();
+                    Ok($(self.$field_name.as_ref(py).eq(&other_inner.$field_name)? &&)* true)
+                } else {
+                    Ok(false)
+                }
+            }
+
+            // This allows match statements with positional sub-patterns.
+            // See https://peps.python.org/pep-0622/#the-match-protocol
+            #[classattr]
+            fn __match_args__<'a>(py: Python<'a>) -> &'a PyTuple {
+                PyTuple::new::<&str, _>(py, [ $(stringify!($field_name),)* ])
+            }
+        }
+    }
+}
+
+dataclass! {
+    struct Test {
+        operator: PyObject,
+        lhs: PyObject,
+        rhs: PyObject,
+    }
+    struct BooleanOperator {
+        operator: PyObject,
+        lhs: PyObject,
+        rhs: PyObject,
+    }
+    struct Latest {
+        inner: PyObject,
+    }
+    struct Single {
+        inner: PyObject,
+    }
+    struct Negation {
+        inner: PyObject,
+    }
+    struct Brackets {
+        inner: PyObject,
+    }
+    struct Literal {
+        value: PyObject,
+    }
+    struct LookupThis {
+        name: Py<PyString>,
+    }
+    struct LookupEnvironment {
+        name: Py<PyString>,
+    }
+    struct LookupParameter {
+        name: Py<PyString>,
+    }
+    struct LookupName;
+    struct LookupId;
+}
+
+#[pyclass]
+enum Operator {
+    Equal,
+    NotEqual,
+    LessThan,
+    LessThanOrEqual,
+    GreaterThan,
+    GreaterThanOrEqual,
+    And,
+    Or,
+}
+
+impl From<ParseError> for PyErr {
+    fn from(err: ParseError) -> PyErr {
+        PyValueError::new_err(err.to_string())
+    }
+}
+
+// parse_query uses this for automatic return type conversion.
+// https://github.com/PyO3/pyo3/issues/1595
+impl IntoPy<PyObject> for ast::QueryNode<'_> {
+    fn into_py(self, py: Python) -> PyObject {
+        ToPyObject::to_object(&self, py)
+    }
+}
+
+impl ToPyObject for ast::QueryNode<'_> {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::QueryNode::Latest(None) => Latest {
+                inner: PyNone::get(py).to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::Latest(Some(inner)) => Latest {
+                inner: inner.to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::Single(inner) => Single {
+                inner: inner.to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::Negation(inner) => Negation {
+                inner: inner.to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::Brackets(inner) => Brackets {
+                inner: inner.to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::Test(operator, lhs, rhs) => Test {
+                operator: operator.to_object(py),
+                lhs: lhs.to_object(py),
+                rhs: rhs.to_object(py),
+            }
+            .into_py(py),
+
+            ast::QueryNode::BooleanOperator(operator, lhs, rhs) => BooleanOperator {
+                operator: operator.to_object(py),
+                lhs: lhs.to_object(py),
+                rhs: rhs.to_object(py),
+            }
+            .into_py(py),
+        }
+    }
+}
+
+impl ToPyObject for ast::TestValue<'_> {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::TestValue::Lookup(inner) => inner.to_object(py),
+            ast::TestValue::Literal(inner) => inner.to_object(py),
+        }
+    }
+}
+
+impl ToPyObject for ast::Literal<'_> {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::Literal::Bool(b) => Literal {
+                value: b.to_object(py),
+            },
+            ast::Literal::String(s) => Literal {
+                value: s.to_object(py),
+            },
+            ast::Literal::Number(x) => Literal {
+                value: x.to_object(py),
+            },
+        }
+        .into_py(py)
+    }
+}
+
+impl ToPyObject for ast::Lookup<'_> {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::Lookup::Packet(ast::PacketLookup::Name) => LookupName {}.into_py(py),
+            ast::Lookup::Packet(ast::PacketLookup::Id) => LookupId {}.into_py(py),
+            ast::Lookup::Packet(ast::PacketLookup::Parameter(name)) => LookupParameter {
+                name: name.into_py(py),
+            }
+            .into_py(py),
+
+            ast::Lookup::This(name) => LookupThis {
+                name: name.into_py(py),
+            }
+            .into_py(py),
+
+            ast::Lookup::Environment(name) => LookupEnvironment {
+                name: name.into_py(py),
+            }
+            .into_py(py),
+        }
+    }
+}
+
+impl ToPyObject for ast::Test {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::Test::Equal => Operator::Equal,
+            ast::Test::NotEqual => Operator::NotEqual,
+            ast::Test::LessThan => Operator::LessThan,
+            ast::Test::LessThanOrEqual => Operator::LessThanOrEqual,
+            ast::Test::GreaterThan => Operator::GreaterThan,
+            ast::Test::GreaterThanOrEqual => Operator::GreaterThanOrEqual,
+        }
+        .into_py(py)
+    }
+}
+
+impl ToPyObject for ast::Operator {
+    fn to_object(&self, py: Python) -> PyObject {
+        match self {
+            ast::Operator::And => Operator::And,
+            ast::Operator::Or => Operator::Or,
+        }
+        .into_py(py)
+    }
+}
+

--- a/src/query/python.rs
+++ b/src/query/python.rs
@@ -8,172 +8,122 @@
 //! from outpack_query_parser import parse_query
 //! print(parse_query("name == 'foo'"))
 //! # Prints:
-//! # Test(operator=Operator.Equal, lhs=LookupName(), rhs=Literal(value='foo'))
+//! # Test(operator=TestOperator.Equal, lhs=LookupName(), rhs=Literal(value='foo'))
 //! ```
-//!
-//! Most of the glue is handled by the PyO3 crate. Calling into the actual parser is trivially done
-//! by the [`parse_query`] function. Most of the module's code is responsible for setting a
-//! parallel AST type hiearchy and implementing conversion from the query_types module to these
-//! types.
 
-use crate::query::query_types as ast;
+use crate::query::query_types::{self, Literal, Lookup, PacketLookup, QueryNode, TestValue};
 use crate::query::ParseError;
+use lazy_static::lazy_static;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyNone, PyString, PyTuple};
+use pyo3::types::PyTuple;
 
-#[pyfunction]
-fn parse_query<'a>(input: &'a str) -> Result<ast::QueryNode<'a>, ParseError> {
-    crate::query::parse_query(input)
-}
-
-#[pymodule]
-fn outpack_query_parser(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(parse_query, m)?)?;
-    m.add_class::<Latest>()?;
-    m.add_class::<Single>()?;
-    m.add_class::<Test>()?;
-    m.add_class::<Negation>()?;
-    m.add_class::<Brackets>()?;
-    m.add_class::<BooleanOperator>()?;
-    m.add_class::<Operator>()?;
-    m.add_class::<Literal>()?;
-    m.add_class::<LookupThis>()?;
-    m.add_class::<LookupParameter>()?;
-    m.add_class::<LookupId>()?;
-    m.add_class::<LookupName>()?;
-    Ok(())
-}
-
-/// Concatenate string literals together, interspersing a separator between each element.
+/// Set of Python AST Classes.
 ///
-/// The first argument is the separator. The elements to concatenate are passed as the subsequent
-/// elements.
+/// These generally mirror the native Rust types used by the parser.
+/// Rust-style enums don't have a Python equivalent. These are instead represented with a separate
+/// class for each variant. Variants can be distinguised using `isinstance`:
 ///
-/// ```ignore(https://github.com/rust-lang/rust/issues/97030)
-/// assert_eq!(intersperse!(", ", "a", "b", "c"), "a, b, c");
+/// ```py
+/// if isinstance(node, Literal):
+///     print("Literal: ", node.value)
+/// elif isinstance(node, LookupParameter):
+///     print("Parameter lookup: ", node.name)
 /// ```
-macro_rules! intersperse {
-    ($sep:expr  $(,)?) => { "" };
-    ($sep:expr, $head:expr $(,)?) => { $head };
-    ($sep:expr, $head:expr, $($tail:expr),+ $(,)?) => {
-        concat!($head, $sep, intersperse!($sep, $($tail,)+))
-    };
-}
-
-/// Define a Python class with dataclass-like semantics.
 ///
-/// The class will have a constructor, __repr__ and __eq__ methods and getters for each field.
-///
-/// Fields must be Python values, wrapped in a `Py<T>`, such as `Py<PyAny>`, `Py<PyString>` or
-/// `Py<C>` where `C` is another struct with a `#[pyclass]` annotation.
-macro_rules! dataclass {
-    () => {};
+/// The classes are defined using the dataclasses module and have typical Python semantics.
+#[allow(non_snake_case)]
+struct Classes {
+    Latest: PyObject,
+    Single: PyObject,
+    Negation: PyObject,
+    Brackets: PyObject,
+    Test: PyObject,
+    BooleanExpr: PyObject,
 
-    (struct $name:ident ; $($rest:tt)* ) => {
-        #[pyclass(frozen)]
-        struct $name;
-
-        dataclass_impl!(struct $name { });
-        dataclass!($($rest)*);
-    };
-
-    (struct $name:ident { $($field_name:ident : $field_type:ty),* $(,)? } $($rest:tt)* ) => {
-        #[pyclass(frozen, get_all)]
-        struct $name {
-            $($field_name: $field_type),*
-        }
-        dataclass_impl!(struct $name { $($field_name: $field_type),* });
-        dataclass!($($rest)*);
-    };
+    Literal: PyObject,
+    LookupThis: PyObject,
+    LookupEnvironment: PyObject,
+    LookupParameter: PyObject,
+    LookupId: PyObject,
+    LookupName: PyObject,
 }
 
-macro_rules! dataclass_impl {
-    (struct $name:ident { $($field_name:ident : $field_type:ty),* $(,)? } ) => {
-        #[pymethods]
-        impl $name {
-            #[new]
-            fn new($($field_name: $field_type),*) -> Self {
-                Self { $($field_name,)* }
-            }
+lazy_static! {
+    static ref CLASSES: Classes = {
+        Python::with_gil(|py| {
+            let dataclasses = py.import("dataclasses").unwrap();
+            let make_dataclass = |name, fields: &[&str]| -> PyObject {
+                let fields = PyTuple::new(py, fields);
+                dataclasses
+                    .call_method1("make_dataclass", (name, fields))
+                    .unwrap()
+                    .into()
+            };
 
-            fn __repr__(&self, #[allow(unused)] py: Python<'_>) -> PyResult<String> {
-                Ok(format!(concat!(
-                    stringify!($name),
-                    "(",
-                    intersperse!(", ", $(concat!(stringify!($field_name), "={}"),)*),
-                    ")"), $(self.$field_name.as_ref(py).repr()?),*))
-            }
+            Classes {
+                Latest: make_dataclass("Latest", &["inner"]),
+                Single: make_dataclass("Single", &["inner"]),
+                Brackets: make_dataclass("Brackets", &["inner"]),
+                Negation: make_dataclass("Negation", &["inner"]),
+                Test: make_dataclass("Test", &["operator", "lhs", "rhs"]),
+                BooleanExpr: make_dataclass("BooleanExpr", &["operator", "lhs", "rhs"]),
 
-            fn __eq__(&self, py: Python<'_>, other: PyObject) -> PyResult<bool> {
-                if let Ok(other) = other.downcast::<PyCell<Self>>(py) {
-                    #[allow(unused)]
-                    let other_inner = other.get();
-                    Ok($(self.$field_name.as_ref(py).eq(&other_inner.$field_name)? &&)* true)
-                } else {
-                    Ok(false)
-                }
+                Literal: make_dataclass("Literal", &["value"]),
+                LookupThis: make_dataclass("LookupThis", &["name"]),
+                LookupEnvironment: make_dataclass("LookupEnvironment", &["name"]),
+                LookupParameter: make_dataclass("LookupParameter", &["name"]),
+                LookupId: make_dataclass("LookupId", &[]),
+                LookupName: make_dataclass("LookupName", &[]),
             }
-
-            // This allows match statements with positional sub-patterns.
-            // See https://peps.python.org/pep-0622/#the-match-protocol
-            #[classattr]
-            fn __match_args__<'a>(py: Python<'a>) -> &'a PyTuple {
-                PyTuple::new::<&str, _>(py, [ $(stringify!($field_name),)* ])
-            }
-        }
-    }
-}
-
-dataclass! {
-    struct Test {
-        operator: PyObject,
-        lhs: PyObject,
-        rhs: PyObject,
-    }
-    struct BooleanOperator {
-        operator: PyObject,
-        lhs: PyObject,
-        rhs: PyObject,
-    }
-    struct Latest {
-        inner: PyObject,
-    }
-    struct Single {
-        inner: PyObject,
-    }
-    struct Negation {
-        inner: PyObject,
-    }
-    struct Brackets {
-        inner: PyObject,
-    }
-    struct Literal {
-        value: PyObject,
-    }
-    struct LookupThis {
-        name: Py<PyString>,
-    }
-    struct LookupEnvironment {
-        name: Py<PyString>,
-    }
-    struct LookupParameter {
-        name: Py<PyString>,
-    }
-    struct LookupName;
-    struct LookupId;
+        })
+    };
 }
 
 #[pyclass]
-enum Operator {
+enum BooleanOperator {
+    And,
+    Or,
+}
+
+#[pyclass]
+enum TestOperator {
     Equal,
     NotEqual,
     LessThan,
     LessThanOrEqual,
     GreaterThan,
     GreaterThanOrEqual,
-    And,
-    Or,
+}
+
+#[pyfunction]
+fn parse_query<'a>(py: Python, input: &'a str) -> PyResult<PyObject> {
+    convert_query(py, crate::query::parse_query(input)?)
+}
+
+#[pymodule]
+fn outpack_query_parser(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(parse_query, m)?)?;
+
+    m.add("Latest", &CLASSES.Latest)?;
+    m.add("Single", &CLASSES.Single)?;
+    m.add("Brackets", &CLASSES.Brackets)?;
+    m.add("Negation", &CLASSES.Negation)?;
+    m.add("Test", &CLASSES.Test)?;
+    m.add("BooleanExpr", &CLASSES.BooleanExpr)?;
+
+    m.add("Literal", &CLASSES.Literal)?;
+    m.add("LookupThis", &CLASSES.LookupThis)?;
+    m.add("LookupEnvironment", &CLASSES.LookupEnvironment)?;
+    m.add("LookupParameter", &CLASSES.LookupParameter)?;
+    m.add("LookupId", &CLASSES.LookupId)?;
+    m.add("LookupName", &CLASSES.LookupName)?;
+
+    // PyO3's `#[pyclass]` does a decent job of generating idiomatic code for enums that don't have
+    // any data. We can just use these rather than eg. calling the Python `enum` package.
+    m.add_class::<BooleanOperator>()?;
+    m.add_class::<TestOperator>()?;
+    Ok(())
 }
 
 impl From<ParseError> for PyErr {
@@ -182,129 +132,77 @@ impl From<ParseError> for PyErr {
     }
 }
 
-// parse_query uses this for automatic return type conversion.
-// https://github.com/PyO3/pyo3/issues/1595
-impl IntoPy<PyObject> for ast::QueryNode<'_> {
-    fn into_py(self, py: Python) -> PyObject {
-        ToPyObject::to_object(&self, py)
+fn convert_query(py: Python, query: QueryNode) -> PyResult<PyObject> {
+    match query {
+        QueryNode::Latest(None) => CLASSES.Latest.call1(py, (py.None(),)),
+        QueryNode::Latest(Some(inner)) => CLASSES.Latest.call1(py, (convert_query(py, *inner)?,)),
+        QueryNode::Single(inner) => CLASSES.Single.call1(py, (convert_query(py, *inner)?,)),
+        QueryNode::Negation(inner) => CLASSES.Negation.call1(py, (convert_query(py, *inner)?,)),
+        QueryNode::Brackets(inner) => CLASSES.Brackets.call1(py, (convert_query(py, *inner)?,)),
+
+        QueryNode::Test(test_type, lhs, rhs) => CLASSES.Test.call1(
+            py,
+            (
+                test_type.to_object(py),
+                convert_test_value(py, lhs)?,
+                convert_test_value(py, rhs)?,
+            ),
+        ),
+
+        QueryNode::BooleanExpr(operator, lhs, rhs) => CLASSES.BooleanExpr.call1(
+            py,
+            (
+                operator.to_object(py),
+                convert_query(py, *lhs)?,
+                convert_query(py, *rhs)?,
+            ),
+        ),
     }
 }
 
-impl ToPyObject for ast::QueryNode<'_> {
-    fn to_object(&self, py: Python) -> PyObject {
-        match self {
-            ast::QueryNode::Latest(None) => Latest {
-                inner: PyNone::get(py).to_object(py),
-            }
-            .into_py(py),
+fn convert_test_value(py: Python, test_value: TestValue) -> PyResult<PyObject> {
+    match test_value {
+        TestValue::Lookup(Lookup::Packet(PacketLookup::Name)) => CLASSES.LookupName.call0(py),
+        TestValue::Lookup(Lookup::Packet(PacketLookup::Id)) => CLASSES.LookupId.call0(py),
+        TestValue::Lookup(Lookup::Packet(PacketLookup::Parameter(name))) => {
+            CLASSES.LookupParameter.call1(py, (name,))
+        }
+        TestValue::Lookup(Lookup::This(name)) => CLASSES.LookupThis.call1(py, (name,)),
+        TestValue::Lookup(Lookup::Environment(name)) => {
+            CLASSES.LookupEnvironment.call1(py, (name,))
+        }
 
-            ast::QueryNode::Latest(Some(inner)) => Latest {
-                inner: inner.to_object(py),
-            }
-            .into_py(py),
-
-            ast::QueryNode::Single(inner) => Single {
-                inner: inner.to_object(py),
-            }
-            .into_py(py),
-
-            ast::QueryNode::Negation(inner) => Negation {
-                inner: inner.to_object(py),
-            }
-            .into_py(py),
-
-            ast::QueryNode::Brackets(inner) => Brackets {
-                inner: inner.to_object(py),
-            }
-            .into_py(py),
-
-            ast::QueryNode::Test(operator, lhs, rhs) => Test {
-                operator: operator.to_object(py),
-                lhs: lhs.to_object(py),
-                rhs: rhs.to_object(py),
-            }
-            .into_py(py),
-
-            ast::QueryNode::BooleanOperator(operator, lhs, rhs) => BooleanOperator {
-                operator: operator.to_object(py),
-                lhs: lhs.to_object(py),
-                rhs: rhs.to_object(py),
-            }
-            .into_py(py),
+        TestValue::Literal(literal) => {
+            let value = match literal {
+                Literal::Bool(b) => b.to_object(py),
+                Literal::String(s) => s.to_object(py),
+                Literal::Number(n) => n.to_object(py),
+            };
+            CLASSES.Literal.call1(py, (value,))
         }
     }
 }
 
-impl ToPyObject for ast::TestValue<'_> {
+impl ToPyObject for query_types::TestOperator {
     fn to_object(&self, py: Python) -> PyObject {
         match self {
-            ast::TestValue::Lookup(inner) => inner.to_object(py),
-            ast::TestValue::Literal(inner) => inner.to_object(py),
-        }
-    }
-}
-
-impl ToPyObject for ast::Literal<'_> {
-    fn to_object(&self, py: Python) -> PyObject {
-        match self {
-            ast::Literal::Bool(b) => Literal {
-                value: b.to_object(py),
-            },
-            ast::Literal::String(s) => Literal {
-                value: s.to_object(py),
-            },
-            ast::Literal::Number(x) => Literal {
-                value: x.to_object(py),
-            },
+            query_types::TestOperator::Equal => TestOperator::Equal,
+            query_types::TestOperator::NotEqual => TestOperator::NotEqual,
+            query_types::TestOperator::LessThan => TestOperator::LessThan,
+            query_types::TestOperator::LessThanOrEqual => TestOperator::LessThanOrEqual,
+            query_types::TestOperator::GreaterThan => TestOperator::GreaterThan,
+            query_types::TestOperator::GreaterThanOrEqual => TestOperator::GreaterThanOrEqual,
         }
         .into_py(py)
     }
 }
 
-impl ToPyObject for ast::Lookup<'_> {
+impl ToPyObject for query_types::BooleanOperator {
     fn to_object(&self, py: Python) -> PyObject {
         match self {
-            ast::Lookup::Packet(ast::PacketLookup::Name) => LookupName {}.into_py(py),
-            ast::Lookup::Packet(ast::PacketLookup::Id) => LookupId {}.into_py(py),
-            ast::Lookup::Packet(ast::PacketLookup::Parameter(name)) => LookupParameter {
-                name: name.into_py(py),
-            }
-            .into_py(py),
-
-            ast::Lookup::This(name) => LookupThis {
-                name: name.into_py(py),
-            }
-            .into_py(py),
-
-            ast::Lookup::Environment(name) => LookupEnvironment {
-                name: name.into_py(py),
-            }
-            .into_py(py),
-        }
-    }
-}
-
-impl ToPyObject for ast::Test {
-    fn to_object(&self, py: Python) -> PyObject {
-        match self {
-            ast::Test::Equal => Operator::Equal,
-            ast::Test::NotEqual => Operator::NotEqual,
-            ast::Test::LessThan => Operator::LessThan,
-            ast::Test::LessThanOrEqual => Operator::LessThanOrEqual,
-            ast::Test::GreaterThan => Operator::GreaterThan,
-            ast::Test::GreaterThanOrEqual => Operator::GreaterThanOrEqual,
+            query_types::BooleanOperator::And => BooleanOperator::And,
+            query_types::BooleanOperator::Or => BooleanOperator::Or,
         }
         .into_py(py)
     }
 }
-
-impl ToPyObject for ast::Operator {
-    fn to_object(&self, py: Python) -> PyObject {
-        match self {
-            ast::Operator::And => Operator::And,
-            ast::Operator::Or => Operator::Or,
-        }
-        .into_py(py)
-    }
-}
-

--- a/src/query/query_parse.rs
+++ b/src/query/query_parse.rs
@@ -65,11 +65,7 @@ pub fn parse_body(pairs: Pairs<Rule>) -> Result<QueryNode, ParseError> {
                 Rule::or => BooleanOperator::Or,
                 rule => unreachable!("Parse expected infix operation, found {:?}", rule),
             };
-            Ok(QueryNode::BooleanExpr(
-                op,
-                Box::new(lhs?),
-                Box::new(rhs?),
-            ))
+            Ok(QueryNode::BooleanExpr(op, Box::new(lhs?), Box::new(rhs?)))
         })
         .parse(pairs)
 }

--- a/src/query/query_types.rs
+++ b/src/query/query_types.rs
@@ -37,7 +37,7 @@ impl<'a> PartialOrd for Literal<'a> {
 }
 
 #[derive(Debug)]
-pub enum Test {
+pub enum TestOperator {
     Equal,
     NotEqual,
     LessThan,
@@ -47,7 +47,7 @@ pub enum Test {
 }
 
 #[derive(Debug)]
-pub enum Operator {
+pub enum BooleanOperator {
     And,
     Or,
 }
@@ -56,10 +56,10 @@ pub enum Operator {
 pub enum QueryNode<'a> {
     Latest(Option<Box<QueryNode<'a>>>),
     Single(Box<QueryNode<'a>>),
-    Test(Test, TestValue<'a>, TestValue<'a>),
     Negation(Box<QueryNode<'a>>),
     Brackets(Box<QueryNode<'a>>),
-    BooleanOperator(Operator, Box<QueryNode<'a>>, Box<QueryNode<'a>>),
+    Test(TestOperator, TestValue<'a>, TestValue<'a>),
+    BooleanExpr(BooleanOperator, Box<QueryNode<'a>>, Box<QueryNode<'a>>),
 }
 
 #[cfg(test)]

--- a/src/query/test_utils_query.rs
+++ b/src/query/test_utils_query.rs
@@ -3,7 +3,7 @@ pub mod tests {
     use crate::query::query_types::*;
 
     pub fn assert_query_node_lookup_number_eq(node: QueryNode, lookup: TestValue, test: f64) {
-        if let QueryNode::Test(Test::Equal, lhs, rhs) = node {
+        if let QueryNode::Test(TestOperator::Equal, lhs, rhs) = node {
             assert_eq!(lhs, lookup);
             match rhs {
                 TestValue::Literal(Literal::Number(value)) => assert_eq!(value, test),

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,0 +1,7 @@
+import sys
+
+collect_ignore = []
+
+if sys.version_info < (3, 10):
+    # This test uses pattern matching, which isn't supported in older Python versions.
+    collect_ignore.append("test_pattern_match.py")

--- a/tests/python/test_parse.py
+++ b/tests/python/test_parse.py
@@ -12,22 +12,3 @@ def test_parse():
 def test_error():
     with pytest.raises(ValueError, match="expected query"):
         parse_query("foo")
-
-def test_pattern_match():
-    match parse_query("latest"):
-        case Latest(None):
-            pass
-        case _:
-            pytest.fail("pattern did not match")
-
-    match parse_query("latest(name == 'foo')"):
-        case Latest(NodeTest()):
-            pass
-        case _:
-            pytest.fail("pattern did not match")
-
-    match parse_query("name == 'foo'"):
-        case NodeTest(Operator.Equal, LookupName, Literal("foo")):
-            pass
-        case _:
-            pytest.fail("pattern did not match")

--- a/tests/python/test_parse.py
+++ b/tests/python/test_parse.py
@@ -1,13 +1,13 @@
 import pytest
-from outpack_query_parser import parse_query, Latest, Operator, Literal, LookupName, Literal
+from outpack_query_parser import parse_query, Latest, Literal, LookupName, Literal
 
-# Calling this Test makes pytest think it's a test class and freak out
-from outpack_query_parser import Test as NodeTest
+# Importing Test* types makes pytest freak out. Use a short module name instead.
+import outpack_query_parser as parser
 
 def test_parse():
     assert parse_query("latest") == Latest(None)
     assert parse_query("latest()") == Latest(None)
-    assert parse_query("name == 'foo'") == NodeTest(Operator.Equal, LookupName(), Literal("foo"))
+    assert parse_query("name == 'foo'") == parser.Test(parser.TestOperator.Equal, LookupName(), Literal("foo"))
 
 def test_error():
     with pytest.raises(ValueError, match="expected query"):

--- a/tests/python/test_parse.py
+++ b/tests/python/test_parse.py
@@ -1,0 +1,33 @@
+import pytest
+from outpack_query_parser import parse_query, Latest, Operator, Literal, LookupName, Literal
+
+# Calling this Test makes pytest think it's a test class and freak out
+from outpack_query_parser import Test as NodeTest
+
+def test_parse():
+    assert parse_query("latest") == Latest(None)
+    assert parse_query("latest()") == Latest(None)
+    assert parse_query("name == 'foo'") == NodeTest(Operator.Equal, LookupName(), Literal("foo"))
+
+def test_error():
+    with pytest.raises(ValueError, match="expected query"):
+        parse_query("foo")
+
+def test_pattern_match():
+    match parse_query("latest"):
+        case Latest(None):
+            pass
+        case _:
+            pytest.fail("pattern did not match")
+
+    match parse_query("latest(name == 'foo')"):
+        case Latest(NodeTest()):
+            pass
+        case _:
+            pytest.fail("pattern did not match")
+
+    match parse_query("name == 'foo'"):
+        case NodeTest(Operator.Equal, LookupName, Literal("foo")):
+            pass
+        case _:
+            pytest.fail("pattern did not match")

--- a/tests/python/test_pattern_match.py
+++ b/tests/python/test_pattern_match.py
@@ -1,0 +1,24 @@
+import pytest
+from outpack_query_parser import parse_query, Latest, Operator, Literal, LookupName, Literal
+
+# Calling this Test makes pytest think it's a test class and freak out
+from outpack_query_parser import Test as NodeTest
+
+def test_pattern_match():
+    match parse_query("latest"):
+        case Latest(None):
+            pass
+        case _:
+            pytest.fail("pattern did not match")
+
+    match parse_query("latest(name == 'foo')"):
+        case Latest(NodeTest()):
+            pass
+        case _:
+            pytest.fail("pattern did not match")
+
+    match parse_query("name == 'foo'"):
+        case NodeTest(Operator.Equal, LookupName, Literal("foo")):
+            pass
+        case _:
+            pytest.fail("pattern did not match")

--- a/tests/python/test_pattern_match.py
+++ b/tests/python/test_pattern_match.py
@@ -1,8 +1,8 @@
 import pytest
-from outpack_query_parser import parse_query, Latest, Operator, Literal, LookupName, Literal
+from outpack_query_parser import parse_query, Latest, Literal, LookupName, Literal
 
-# Calling this Test makes pytest think it's a test class and freak out
-from outpack_query_parser import Test as NodeTest
+# Importing Test* types makes pytest freak out. Use a short module name instead.
+import outpack_query_parser as parser
 
 def test_pattern_match():
     match parse_query("latest"):
@@ -12,13 +12,13 @@ def test_pattern_match():
             pytest.fail("pattern did not match")
 
     match parse_query("latest(name == 'foo')"):
-        case Latest(NodeTest()):
+        case Latest(parser.Test()):
             pass
         case _:
             pytest.fail("pattern did not match")
 
     match parse_query("name == 'foo'"):
-        case NodeTest(Operator.Equal, LookupName, Literal("foo")):
+        case parser.Test(parser.TestOperator.Equal, LookupName, Literal("foo")):
             pass
         case _:
             pytest.fail("pattern did not match")


### PR DESCRIPTION
The existing query parser is exposed as a new Python package called `outpack_query_parser`. The package contains a single function, `parse_query` which turns a string into an AST.

The AST is represented with Python objects, and can be printed and pattern matched on.