### PR TITLE
Fix path issues on Windows.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -8,8 +8,16 @@ name: test
 
 jobs:
   build_and_test:
-    name: Rust project
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest}
+          - {os: macos-latest}
+          - {os: windows-latest}
+
+    name: ${{matrix.config.os }}
+    runs-on: ${{ matrix.config.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
`put_file` (and its unit tests) was using the hash, including the hash type with its colon separator, as part of a temporary filename. This is not supported on Windows. The actual temporary file name does not matter, so give it a dummy name.

Also fixes a test assertion that assumed forward slash path separators.