### PR TITLE
mrc-4786: Build Python wheels in CI.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -11,42 +11,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config:
-          - {os: ubuntu-latest,  py: '3.8'}
-          - {os: ubuntu-latest,  py: '3.9'}
-          - {os: ubuntu-latest,  py: '3.10'}
-          - {os: ubuntu-latest,  py: '3.11'}
-          - {os: macos-latest,   py: '3.11'}
-          - {os: windows-latest, py: '3.11'}
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
-    name: ${{matrix.config.os }} (${{ matrix.config.py }})
-    runs-on: ${{ matrix.config.os }}
-
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-          components: clippy
-      - name: Set up Python ${{ matrix.config.py }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.config.py }}
       - name: Lint
         run: cargo clippy -- -D warnings
       - name: Format check
         run: cargo fmt --check
-      - name: Check
-        run: cargo check --release --all-features
-      - name: Test
+      - name: Build (debug)
+        run: cargo build
+      - name: Test (debug)
         run: cargo test
-
-      - name: Install python dependencies
-        run: |
-          python -m pip install --upgrade pip build
-          pip install hatch
-
-      - name: Run Python tests
-        run: |
-          hatch run test
+      - name: Build (release)
+        run: cargo build --release
+      - name: Test (release)
+        run: cargo test --release

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,0 +1,115 @@
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+name: Build, Test and Publish Python Bindings
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python tooling
+        run: |
+          python -m pip install hatch
+
+      - name: Run Python tests
+        run: |
+          hatch run test
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+      - name: Install pypa/build
+        run: |
+          python -m pip install build
+      - name: Build source distribution
+        run: |
+          python -m build --sdist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: python-artifacts
+          path: dist
+
+  build-wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-latest,  target: 'x86_64'}
+          - {os: ubuntu-latest,  target: 'x86'}
+          - {os: ubuntu-latest,  target: 'aarch64'}
+          - {os: windows-latest, target: 'x64'}
+          - {os: windows-latest, target: 'x86'}
+          - {os: macos-latest,   target: 'x86_64'}
+          - {os: macos-latest,   target: 'aarch64'}
+
+    runs-on: ${{ matrix.config.os }}
+    name: Build wheels for ${{ matrix.config.os }} (${{ matrix.config.target }})
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        if: matrix.config.os == 'windows-latest'
+        with:
+          python-version: "3.x"
+          architecture: ${{ matrix.config.target }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.config.target }}
+          args: --release --out dist
+          manylinux: manylinux2014
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          if-no-files-found: error
+          name: python-artifacts
+          path: dist
+
+  # This assumes a PyPI Trusted Publisher has been configure for the `outpack_query_parser` package.
+  # See https://docs.pypi.org/trusted-publishers/ for more details.
+  publish-to-pypi:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    name: Publish Python distribution to PyPI
+    needs:
+      - build-sdist
+      - build-wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/outpack_query_parser
+    permissions:
+      # This permission is needed for the workflow to authenticate against PyPI
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-artifacts
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tempfile = "3.6.0"
 clap = { version = "4.4.8", features = ["derive"] }
 anyhow = "1.0.75"
 thiserror = "1.0.50"
-pyo3 = { version = "0.20.0", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py38"], optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ features = ["python"]
 path = "Cargo.toml"
 
 [tool.hatch.envs.default]
-dependencies = [ "pytest" ]
+dependencies = [ "maturin", "pytest" ]
 
 [tool.hatch.envs.default.scripts]
 test = "pytest {args:tests/python}"


### PR DESCRIPTION
This will allow users to install and import the Python bindings without needing to install a Rust toolchain.

The wheels should work on most mainstream platforms and architecture. We can add more if it turns out there's a gap somewhere. Additionally it uses abi3 wheels, which will work on any Python version >= 3.8, see https://pyo3.rs/v0.20.0/building_and_distribution#py_limited_apiabi3

The wheels are built unconditionally on every commit to master and PR commit. Additionally, whenever a tag is created the source package and wheels are pushed to PyPI.

I used TestPyPi to check the publish process and it seems to work fine. Of course there's a small chance this will not work on the first release attempt and need a bit more iteration later on.