### PR TITLE
MRC 4770 - Add time field and remove custom from packit endpoint

### DIFF
--- a/schema/server/list.json
+++ b/schema/server/list.json
@@ -17,10 +17,16 @@
                 "description": "Task parameters, used when running and for querying",
                 "type": ["null", "object"]
             },
-
-            "custom": {
-                "description": "Optional custom metadata, grouped under application keys",
-                "type": ["null", "object"]
+            "time": {
+                "description": "Information about the running time",
+                "start": {
+                    "description": "Time that the report was started, in seconds since 1970-01-01",
+                    "type": "number"
+                },
+                "end": {
+                    "description": "Time that the report was completed, in seconds since 1970-01-01",
+                    "type": "number"
+                }
             }
         },
         "required": ["id", "name"],

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -17,8 +17,8 @@ use super::utils;
 pub struct PackitPacket {
     pub id: String,
     pub name: String,
-    pub custom: Option<serde_json::Value>,
     pub parameters: Option<HashMap<String, serde_json::Value>>,
+    pub time: PacketTime,
 }
 
 impl PackitPacket {
@@ -26,8 +26,8 @@ impl PackitPacket {
         PackitPacket {
             id: packet.id.to_string(),
             name: packet.name.to_string(),
-            custom: packet.custom.clone(),
             parameters: packet.parameters.clone(),
+            time: packet.time.clone(),
         }
     }
 }
@@ -40,6 +40,7 @@ pub struct Packet {
     pub parameters: Option<HashMap<String, serde_json::Value>>,
     pub files: Vec<PacketFile>,
     pub depends: Vec<PacketDependency>,
+    pub time: PacketTime,
 }
 
 impl PartialEq for Packet {
@@ -67,6 +68,12 @@ pub struct PacketFile {
 pub struct PacketDependency {
     packet: String,
     files: Vec<DependencyFile>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct PacketTime {
+    start: f64,
+    end: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -182,22 +182,13 @@ fn can_list_metadata() {
         "YF"
     );
     assert_eq!(
-        entries[0]
-            .get("custom")
-            .unwrap()
-            .as_object()
-            .unwrap()
-            .get("orderly")
-            .unwrap()
-            .as_object()
-            .unwrap()
-            .get("displayname")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Modified Update"
+        entries[0].get("time").unwrap().get("start").unwrap(),
+        1503074938.2232
     );
-
+    assert_eq!(
+        entries[0].get("time").unwrap().get("end").unwrap(),
+        1503074938.2232
+    );
     assert_eq!(
         entries[1].get("id").unwrap().as_str().unwrap(),
         "20170818-164847-7574883b"


### PR DESCRIPTION
This PR alters data returned from enpoint `/packit/metadata?<known_since>` used by packit... This adds time field and removes custom field.