### PR TITLE
mrc-5002: Add a /metrics endpoint with basic metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "cookie"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7efb37c3e1ccb1ff97164ad95ac1606e8ccd35b3fa0a7d99a304c7f4a428cc24"
+checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
 dependencies = [
  "percent-encoding",
  "time",
@@ -836,7 +836,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -847,6 +846,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]
@@ -1248,6 +1248,7 @@ dependencies = [
  "pyo3",
  "regex",
  "rocket",
+ "rocket_prometheus",
  "serde",
  "serde_json",
  "sha1",
@@ -1297,7 +1298,7 @@ checksum = "0ec95680a7087503575284e5063e14b694b7a9c0b065e5dceec661e0497127e8"
 dependencies = [
  "inlinable_string",
  "pear_codegen",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -1441,7 +1442,21 @@ dependencies = [
  "quote",
  "syn 2.0.32",
  "version_check",
- "yansi",
+ "yansi 0.5.1",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -1696,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58734f7401ae5cfd129685b48f61182331745b357b96f2367f01aebaf1cc9cc9"
+checksum = "9e7bb57ccb26670d73b6a47396c83139447b9e7878cab627fdfe9ea8da489150"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -1708,8 +1723,7 @@ dependencies = [
  "either",
  "figment",
  "futures",
- "indexmap 1.9.3",
- "is-terminal",
+ "indexmap 2.0.0",
  "log",
  "memchr",
  "multer",
@@ -1730,37 +1744,38 @@ dependencies = [
  "tokio-util",
  "ubyte",
  "version_check",
- "yansi",
+ "yansi 1.0.0-rc.1",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7093353f14228c744982e409259fb54878ba9563d08214f2d880d59ff2fc508b"
+checksum = "a2238066abf75f21be6cd7dc1a09d5414a671f4246e384e49fe3f8a4936bd04c"
 dependencies = [
  "devise",
  "glob",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "proc-macro2",
  "quote",
  "rocket_http",
  "syn 2.0.32",
  "unicode-xid",
+ "version_check",
 ]
 
 [[package]]
 name = "rocket_http"
-version = "0.5.0-rc.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936012c99162a03a67f37f9836d5f938f662e26f2717809761a9ac46432090f4"
+checksum = "37a1663694d059fe5f943ea5481363e48050acedd241d46deb2e27f71110389e"
 dependencies = [
  "cookie",
  "either",
  "futures",
  "http",
  "hyper",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "log",
  "memchr",
  "pear",
@@ -1774,6 +1789,16 @@ dependencies = [
  "time",
  "tokio",
  "uncased",
+]
+
+[[package]]
+name = "rocket_prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18faabccdfcd08d4501768f5b6936f6332af10496f1ea8107eb48a7766e03439"
+dependencies = [
+ "prometheus",
+ "rocket",
 ]
 
 [[package]]
@@ -1976,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "state"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b"
+checksum = "2b8c4a4445d81357df8b1a650d0d0d6fbbbfe99d064aa5e02f3e4022061476d8"
 dependencies = [
  "loom",
 ]
@@ -2227,11 +2252,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2239,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2250,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2640,3 +2664,12 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+dependencies = [
+ "is-terminal",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.70"
 crate-type = ["rlib", "cdylib"]
 
 [dependencies]
-rocket = { version = "0.5.0-rc.2", features = ["json"] }
+rocket = { version = "0.5.0", features = ["json"] }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
@@ -26,6 +26,7 @@ clap = { version = "4.4.8", features = ["derive"] }
 anyhow = "1.0.75"
 thiserror = "1.0.50"
 pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py38"], optional = true }
+rocket_prometheus = "0.10.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,6 +13,7 @@ use crate::location;
 use crate::metadata;
 use crate::responses;
 use crate::store;
+use rocket_prometheus::PrometheusMetrics;
 
 use crate::outpack_file::OutpackFile;
 use responses::{FailResponse, OutpackError, OutpackSuccess};
@@ -204,8 +205,11 @@ pub fn preflight(root_path: &str) -> anyhow::Result<()> {
 }
 
 fn api_build(root: &str) -> Rocket<Build> {
+    let prometheus = PrometheusMetrics::new();
     rocket::build()
         .manage(String::from(root))
+        .attach(prometheus.clone())
+        .mount("/metrics", prometheus)
         .register("/", catchers![internal_error, not_found, bad_request])
         .mount(
             "/",

--- a/src/store.rs
+++ b/src/store.rs
@@ -77,10 +77,10 @@ mod tests {
     #[rocket::async_test]
     async fn put_file_is_idempotent() {
         let root = get_temp_outpack_root();
-        let data = "Testing 123.";
+        let data = b"Testing 123.";
         let mut temp_file = TempFile::Buffered { content: data };
         temp_file.persist_to(root.join("input.txt")).await.unwrap();
-        let hash = hash_data(data.as_bytes(), HashAlgorithm::Sha256);
+        let hash = hash_data(data, HashAlgorithm::Sha256);
         let hash_str = hash.to_string();
 
         let root_str = root.to_str().unwrap();
@@ -88,7 +88,7 @@ mod tests {
         let expected = file_path(root_str, &hash_str).unwrap();
         let expected = expected.to_str().unwrap();
         assert!(res.is_ok());
-        assert_eq!(fs::read_to_string(expected).unwrap(), data);
+        assert_eq!(fs::read(expected).unwrap(), data);
 
         let mut temp_file = TempFile::Buffered { content: data };
         temp_file.persist_to(root.join("input.txt")).await.unwrap();
@@ -100,7 +100,7 @@ mod tests {
     #[rocket::async_test]
     async fn put_file_validates_hash_format() {
         let root = get_temp_outpack_root();
-        let data = "Testing 123.";
+        let data = b"Testing 123.";
         let mut temp_file = TempFile::Buffered { content: data };
         temp_file.persist_to(root.join("input.txt")).await.unwrap();
         let root_path = root.to_str().unwrap();
@@ -114,7 +114,7 @@ mod tests {
     #[rocket::async_test]
     async fn put_file_validates_hash_match() {
         let root = get_temp_outpack_root();
-        let data = "Testing 123.";
+        let data = b"Testing 123.";
         let mut temp_file = TempFile::Buffered { content: data };
         temp_file.persist_to(root.join("input.txt")).await.unwrap();
         let root_path = root.to_str().unwrap();


### PR DESCRIPTION
The endpoint will allow Prometheus to scrape metrics from the service. For now, only basic information about request count and timing is exposed, through the `rocket_prometheus` crate. The same crate provides the implementation of the endpoint too.

The crate looks for metrics in a global registry, which will allow us to add some of our own metrics in the future.

The response of the `/metrics` is formatted according to Prometheus' [text-based exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/)

Below is an example of what the endpoint looks like, after just one request to the `/` endpoint:
```
# HELP rocket_http_requests_duration_seconds HTTP request duration in seconds for all requests
# TYPE rocket_http_requests_duration_seconds histogram
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.005"} 1
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.01"} 1
[...]
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="+Inf"} 1
rocket_http_requests_duration_seconds_sum{endpoint="/",method="GET",status="200"} 0.000584065
rocket_http_requests_duration_seconds_count{endpoint="/",method="GET",status="200"} 1
# HELP rocket_http_requests_total Total number of HTTP requests
# TYPE rocket_http_requests_total counter
rocket_http_requests_total{endpoint="/",method="GET",status="200"} 1
```

The endpoint label of the metrics always matches the template that we fill in as the argument to the `rocket::get` or `rocket::post` macros. In other words, querying the `/metadata/foobar/json` path will create metrics that use `/metadata/<id>/json` as their label. This is important to make aggregation work, and avoid blowing up the total number of metrics.

Update to Rocket 0.5.0 (from 0.5.0-rc2). This is almost drop-in, just some minor changes to the `TempFile::Buffered` API used in tests (it now takes a byte slice instead of an `&str`).