### PR TITLE
mrc-5011: Add gauges to monitor the size of the repository.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +323,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +392,12 @@ dependencies = [
  "time",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpufeatures"
@@ -805,11 +840,34 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -968,9 +1026,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "linux-raw-sys"
@@ -996,9 +1054,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loom"
@@ -1068,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
 dependencies = [
  "libc",
  "wasi",
@@ -1237,15 +1295,19 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "cached",
+ "chrono",
  "clap",
  "itertools",
  "jsonschema",
  "lazy_static",
+ "log",
  "md5",
  "pest",
  "pest_derive",
  "predicates 2.1.5",
+ "prometheus",
  "pyo3",
+ "rand 0.8.5",
  "regex",
  "rocket",
  "rocket_prometheus",
@@ -1257,6 +1319,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "thiserror",
+ "tokio",
  "url",
  "walkdir",
 ]
@@ -1287,7 +1350,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1365,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1456,8 +1519,15 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot",
+ "protobuf",
  "thiserror",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "pyo3"
@@ -1985,6 +2055,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,11 +2237,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
- "autocfg",
  "backtrace",
  "bytes",
  "libc",
@@ -2169,16 +2248,16 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2563,7 +2642,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2572,7 +2660,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2581,13 +2669,28 @@ version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -2597,10 +2700,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2609,10 +2724,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2621,16 +2748,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ anyhow = "1.0.75"
 thiserror = "1.0.50"
 pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py38"], optional = true }
 rocket_prometheus = "0.10.0"
+prometheus = "0.13.3"
+log = "0.4.20"
+tokio = "1.35.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"
@@ -35,6 +38,8 @@ jsonschema = "0.16.1"
 url = "2.3.1"
 tempdir = "0.3.7"
 tar = "0.4.38"
+chrono = "0.4.33"
+rand = "0.8.5"
 
 [features]
 python = [ "dep:pyo3" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod test_utils;
+
 pub mod api;
 pub mod config;
 pub mod index;
@@ -7,8 +10,8 @@ pub mod query;
 mod hash;
 mod location;
 mod metadata;
+mod metrics;
 mod outpack_file;
 mod responses;
 mod store;
-mod test_utils;
 mod utils;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -59,21 +59,21 @@ impl std::hash::Hash for Packet {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PacketFile {
-    path: String,
-    hash: String,
-    size: usize,
+    pub path: String,
+    pub hash: String,
+    pub size: usize,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PacketDependency {
-    packet: String,
-    files: Vec<DependencyFile>,
+    pub packet: String,
+    pub files: Vec<DependencyFile>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PacketTime {
-    start: f64,
-    end: f64,
+    pub start: f64,
+    pub end: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -170,14 +170,14 @@ pub fn get_ids_digest(root_path: &str, alg_name: Option<String>) -> io::Result<S
         Some(name) => hash::HashAlgorithm::from_str(&name).map_err(hash::hash_error_to_io_error)?,
     };
 
-    let ids = get_ids(root_path, None)?;
+    let ids = get_ids(root_path, false)?;
     let id_string = get_sorted_id_string(ids);
     Ok(hash::hash_data(id_string.as_bytes(), hash_algorithm).to_string())
 }
 
-pub fn get_ids(root_path: &str, unpacked: Option<bool>) -> io::Result<Vec<String>> {
+pub fn get_ids(root_path: &str, unpacked: bool) -> io::Result<Vec<String>> {
     let path = Path::new(root_path).join(".outpack");
-    let path = if unpacked.is_some_and(|x| x) {
+    let path = if unpacked {
         path.join("location").join("local")
     } else {
         path.join("metadata")
@@ -204,7 +204,7 @@ pub fn get_valid_id(id: &String) -> io::Result<String> {
 pub fn get_missing_ids(
     root_path: &str,
     wanted: &[String],
-    unpacked: Option<bool>,
+    unpacked: bool,
 ) -> io::Result<Vec<String>> {
     let known: HashSet<String> = get_ids(root_path, unpacked)?.into_iter().collect();
     let wanted: HashSet<String> = wanted
@@ -242,7 +242,7 @@ fn check_missing_dependencies(root: &str, packet: &Packet) -> Result<(), io::Err
         .map(|d| d.packet.clone())
         .collect::<Vec<String>>();
 
-    let missing_packets = get_missing_ids(root, &deps, Some(true))?;
+    let missing_packets = get_missing_ids(root, &deps, true)?;
     if !missing_packets.is_empty() {
         return Err(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -256,20 +256,36 @@ fn check_missing_dependencies(root: &str, packet: &Packet) -> Result<(), io::Err
     Ok(())
 }
 
-pub fn add_metadata(root: &str, data: &str, hash: &hash::Hash) -> io::Result<()> {
-    let packet: Packet = serde_json::from_str(data)?;
-    let hash_str = hash.to_string();
-
-    hash::validate_hash_data(data.as_bytes(), &hash_str).map_err(hash::hash_error_to_io_error)?;
-    check_missing_files(root, &packet)?;
-    check_missing_dependencies(root, &packet)?;
+fn add_parsed_metadata(root: &str, data: &str, packet: &Packet, hash: &str) -> io::Result<()> {
+    hash::validate_hash_data(data.as_bytes(), &hash).map_err(hash::hash_error_to_io_error)?;
 
     let path = get_path(root, &packet.id);
-
     if !path.exists() {
         fs::File::create(&path)?;
         fs::write(path, data)?;
     }
+    Ok(())
+}
+
+/// Add metadata to the repository.
+#[cfg(test)] // Only used from tests at the moment.
+pub fn add_metadata(root: &str, data: &str, hash: &hash::Hash) -> io::Result<()> {
+    let packet: Packet = serde_json::from_str(data)?;
+    add_parsed_metadata(root, data, &packet, &hash.to_string())
+}
+
+/// Add a packet to the repository.
+///
+/// The packet's files and dependencies must already be present in the repository.
+pub fn add_packet(root: &str, data: &str, hash: &hash::Hash) -> io::Result<()> {
+    let packet: Packet = serde_json::from_str(data)?;
+    let hash_str = hash.to_string();
+
+    check_missing_files(root, &packet)?;
+    check_missing_dependencies(root, &packet)?;
+
+    add_parsed_metadata(root, data, &packet, &hash.to_string())?;
+
     let time = SystemTime::now();
     location::mark_packet_known(&packet.id, "local", &hash_str, time, root)?;
     Ok(())
@@ -278,7 +294,8 @@ pub fn add_metadata(root: &str, data: &str, hash: &hash::Hash) -> io::Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::tests::get_temp_outpack_root;
+    use crate::store::file_exists;
+    use crate::test_utils::tests::{get_temp_outpack_root, start_packet};
     use crate::utils::time_as_num;
     use serde_json::Value;
     use sha2::{Digest, Sha256};
@@ -341,7 +358,7 @@ mod tests {
 
     #[test]
     fn can_get_ids() {
-        let ids = get_ids("tests/example", None).unwrap();
+        let ids = get_ids("tests/example", false).unwrap();
         assert_eq!(ids.len(), 4);
         assert!(ids.iter().any(|e| e == "20170818-164830-33e0ab01"));
         assert!(ids.iter().any(|e| e == "20170818-164847-7574883b"));
@@ -351,7 +368,7 @@ mod tests {
 
     #[test]
     fn can_get_unpacked_ids() {
-        let ids = get_ids("tests/example", Some(true)).unwrap();
+        let ids = get_ids("tests/example", true).unwrap();
         assert_eq!(ids.len(), 1);
         assert!(ids.iter().any(|e| e == "20170818-164847-7574883b"));
     }
@@ -364,7 +381,7 @@ mod tests {
                 "20180818-164043-7cdcde4b".to_string(),
                 "20170818-164830-33e0ab02".to_string(),
             ],
-            None,
+            false,
         )
         .unwrap();
         assert_eq!(ids.len(), 1);
@@ -377,7 +394,7 @@ mod tests {
                 "20180818-164043-7cdcde4b".to_string(),
                 "20170818-164830-33e0ab02".to_string(),
             ],
-            None,
+            false,
         )
         .unwrap();
         assert_eq!(ids.len(), 1);
@@ -392,7 +409,7 @@ mod tests {
                 "20170818-164847-7574883b".to_string(),
                 "20170818-164830-33e0ab02".to_string(),
             ],
-            Some(true),
+            true,
         )
         .unwrap();
         assert_eq!(ids.len(), 1);
@@ -407,14 +424,14 @@ mod tests {
                 "20180818-164043-7cdcde4b".to_string(),
                 "20170818-164830-33e0ab0".to_string(),
             ],
-            None,
+            false,
         )
         .map_err(|e| e.kind());
         assert_eq!(Err(io::ErrorKind::InvalidInput), res);
     }
 
     #[test]
-    fn can_add_metadata() {
+    fn can_add_packet() {
         let data = r#"{
                              "schema_version": "0.0.1",
                               "name": "computed-resource",
@@ -441,14 +458,14 @@ mod tests {
         let hash = hash::hash_data(data.as_bytes(), hash::HashAlgorithm::Sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
-        add_metadata(root_path, data, &hash).unwrap();
+        add_packet(root_path, data, &hash).unwrap();
         let packet = get_metadata_by_id(root_path, "20230427-150828-68772cee").unwrap();
         let expected: Value = serde_json::from_str(data).unwrap();
         assert_eq!(packet, expected);
     }
 
     #[test]
-    fn add_metadata_is_idempotent() {
+    fn add_packet_is_idempotent() {
         let data = r#"{
                              "schema_version": "0.0.1",
                               "name": "computed-resource",
@@ -467,11 +484,11 @@ mod tests {
         let hash = hash::hash_data(data.as_bytes(), hash::HashAlgorithm::Sha256);
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
-        add_metadata(root_path, data, &hash).unwrap();
+        add_packet(root_path, data, &hash).unwrap();
         let packet = get_metadata_by_id(root_path, "20230427-150828-68772cee").unwrap();
         let expected: Value = serde_json::from_str(data).unwrap();
         assert_eq!(packet, expected);
-        add_metadata(root_path, data, &hash).unwrap();
+        add_packet(root_path, data, &hash).unwrap();
     }
 
     #[test]
@@ -495,7 +512,7 @@ mod tests {
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
         let now = SystemTime::now();
-        add_metadata(root_path, data, &hash).unwrap();
+        add_packet(root_path, data, &hash).unwrap();
         let path = Path::new(root_path)
             .join(".outpack")
             .join("location")
@@ -512,61 +529,55 @@ mod tests {
     }
 
     #[test]
-    fn cannot_put_metadata_with_missing_files() {
-        let data = r#"{
-                             "schema_version": "0.0.1",
-                              "name": "computed-resource",
-                              "id": "20230427-150828-68772cee",
-                              "time": {
-                                "start": 1682608108.4139,
-                                "end": 1682608108.4309
-                              },
-                              "parameters": null,
-                              "files": [
-                                {
-                                  "path": "data.csv",
-                                  "size": 51,
-                                  "hash": "sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164"
-                                }
-                              ],
-                              "depends": [],
-                              "script": [
-                                "orderly.R"
-                              ]
-                            }"#;
-        let hash = hash::hash_data(data.as_bytes(), hash::HashAlgorithm::Sha256);
+    fn can_add_metadata_with_missing_files() {
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
-        let res = add_metadata(root_path, data, &hash);
-        assert_eq!(res.unwrap_err().to_string(),
-                   "Can't import metadata for 20230427-150828-68772cee, as files missing: \n sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164");
+
+        let file_hash = "sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164";
+
+        assert!(!file_exists(root_path, file_hash).unwrap());
+
+        let (_, metadata, hash) = start_packet("data")
+            .add_file("data.csv", file_hash, 51)
+            .finish();
+
+        add_metadata(root_path, &metadata, &hash).unwrap();
     }
 
     #[test]
-    fn cannot_put_metadata_with_missing_dependencies() {
-        let data = r#"{
-                             "schema_version": "0.0.1",
-                              "name": "computed-resource",
-                              "id": "20230427-150828-68772cee",
-                              "time": {
-                                "start": 1682608108.4139,
-                                "end": 1682608108.4309
-                              },
-                              "parameters": null,
-                              "files": [],
-                              "depends": [{
-                                "packet": "20230427-150828-68772cea",
-                                "files": []
-                              }],
-                              "script": [
-                                "orderly.R"
-                              ]
-                            }"#;
-        let hash = hash::hash_data(data.as_bytes(), hash::HashAlgorithm::Sha256);
+    fn cannot_add_packet_with_missing_files() {
         let root = get_temp_outpack_root();
         let root_path = root.to_str().unwrap();
-        let res = add_metadata(root_path, data, &hash);
-        assert_eq!(res.unwrap_err().to_string(),
-                   "Can't import metadata for 20230427-150828-68772cee, as dependencies missing: \n 20230427-150828-68772cea");
+
+        let file_hash = "sha256:c7b512b2d14a7caae8968830760cb95980a98e18ca2c2991b87c71529e223164";
+
+        assert!(!file_exists(root_path, file_hash).unwrap());
+
+        let (_, metadata, hash) = start_packet("data")
+            .add_file("data.csv", file_hash, 51)
+            .finish();
+
+        let res = add_packet(root_path, &metadata, &hash);
+        assert_regex!(
+            res.unwrap_err().to_string(),
+            "Can't import metadata for .*, as files missing:"
+        );
+    }
+
+    #[test]
+    fn cannot_add_packet_with_missing_dependencies() {
+        let (dependency_id, _, _) = start_packet("upstream").finish();
+        let (_, metadata, hash) = start_packet("downstream")
+            .add_dependency(dependency_id, vec![])
+            .finish();
+
+        let root = get_temp_outpack_root();
+        let root_path = root.to_str().unwrap();
+
+        let res = add_packet(root_path, &metadata, &hash);
+        assert_regex!(
+            res.unwrap_err().to_string(),
+            "Can't import metadata for .*, as dependencies missing:"
+        );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,164 @@
+use crate::metadata;
+use crate::store;
+use prometheus::{core::Collector, core::Desc, IntGauge, Opts, Registry};
+
+/// A prometheus collector with metrics for the state of the repository.
+///
+/// The metrics are collected lazily whenever the metrics endpoint is called.
+struct RepositoryCollector {
+    root: String,
+    metadata_total: IntGauge,
+    packets_total: IntGauge,
+    files_total: IntGauge,
+    file_size_bytes_total: IntGauge,
+    descs: Vec<Desc>,
+}
+
+impl RepositoryCollector {
+    pub fn new(root: impl Into<String>) -> RepositoryCollector {
+        let namespace = "outpack_server";
+        let make_opts = |name: &str, help: &str| Opts::new(name, help).namespace(namespace);
+
+        let metadata_total = IntGauge::with_opts(make_opts(
+            "metadata_total",
+            "Number of packet metadata in the repository",
+        ))
+        .unwrap();
+
+        let packets_total = IntGauge::with_opts(make_opts(
+            "packets_total",
+            "Number of packets contained in the repository",
+        ))
+        .unwrap();
+
+        let files_total = IntGauge::with_opts(make_opts(
+            "files_total",
+            "Number of files in the repository",
+        ))
+        .unwrap();
+
+        let file_size_bytes_total = IntGauge::with_opts(make_opts(
+            "file_size_bytes_total",
+            "Total file size of the repository, in bytes",
+        ))
+        .unwrap();
+
+        let mut descs = Vec::new();
+        descs.extend(metadata_total.desc().into_iter().cloned());
+        descs.extend(packets_total.desc().into_iter().cloned());
+        descs.extend(files_total.desc().into_iter().cloned());
+        descs.extend(file_size_bytes_total.desc().into_iter().cloned());
+        RepositoryCollector {
+            root: root.into(),
+            metadata_total,
+            packets_total,
+            files_total,
+            file_size_bytes_total,
+            descs,
+        }
+    }
+
+    fn update(&self) -> anyhow::Result<()> {
+        self.metadata_total
+            .set(metadata::get_ids(&self.root, false)?.len() as i64);
+
+        self.packets_total
+            .set(metadata::get_ids(&self.root, true)?.len() as i64);
+
+        let mut files_count = 0;
+        let mut files_size = 0;
+        for f in store::enumerate_files(&self.root) {
+            files_count += 1;
+            files_size += f.metadata()?.len();
+        }
+        self.files_total.set(files_count);
+        self.file_size_bytes_total.set(files_size as i64);
+
+        Ok(())
+    }
+}
+
+impl Collector for RepositoryCollector {
+    fn desc(&self) -> Vec<&prometheus::core::Desc> {
+        self.descs.iter().collect()
+    }
+
+    fn collect(&self) -> Vec<prometheus::proto::MetricFamily> {
+        let mut metrics = Vec::new();
+        if let Err(e) = self.update() {
+            log::error!("error while collecting repository metrics: {}", e);
+        } else {
+            metrics.extend(self.metadata_total.collect());
+            metrics.extend(self.packets_total.collect());
+            metrics.extend(self.files_total.collect());
+            metrics.extend(self.file_size_bytes_total.collect());
+        }
+        metrics
+    }
+}
+
+pub fn register(registry: &Registry, root_path: &str) -> prometheus::Result<()> {
+    registry.register(Box::new(RepositoryCollector::new(root_path)))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hash::hash_data;
+    use crate::hash::HashAlgorithm;
+    use crate::metadata::{add_metadata, add_packet};
+    use crate::store::put_file;
+    use crate::test_utils::tests::{get_empty_outpack_root, start_packet};
+
+    #[test]
+    fn repository_collector_empty_repo() {
+        let root = get_empty_outpack_root().to_str().unwrap().to_owned();
+        let collector = RepositoryCollector::new(&root);
+
+        assert_eq!(collector.metadata_total.get(), 0);
+        assert_eq!(collector.packets_total.get(), 0);
+        assert_eq!(collector.files_total.get(), 0);
+        assert_eq!(collector.file_size_bytes_total.get(), 0);
+    }
+
+    #[tokio::test]
+    async fn repository_collector_files() {
+        let root = get_empty_outpack_root().to_str().unwrap().to_owned();
+        let collector = RepositoryCollector::new(&root);
+
+        let data1 = b"Testing 123";
+        let hash1 = hash_data(data1, HashAlgorithm::Sha256).to_string();
+
+        let data2 = b"More data";
+        let hash2 = hash_data(data2, HashAlgorithm::Sha256).to_string();
+
+        let total_size = data1.len() + data2.len();
+
+        put_file(&root, data1, &hash1).await.unwrap();
+        put_file(&root, data2, &hash2).await.unwrap();
+
+        collector.update().unwrap();
+        assert_eq!(collector.files_total.get(), 2);
+        assert_eq!(collector.file_size_bytes_total.get(), total_size as i64);
+    }
+
+    #[test]
+    fn repository_collector_packets() {
+        let root = get_empty_outpack_root().to_str().unwrap().to_owned();
+        let collector = RepositoryCollector::new(&root);
+
+        // Create two different packets.
+        // One of them is actually added to the repository.
+        // We have the metadata for the second one, but it is missing from the repo.
+        let (_, packet1, hash1) = start_packet("hello").finish();
+        let (_, packet2, hash2) = start_packet("hello").finish();
+
+        add_packet(&root, &packet1, &hash1).unwrap();
+        add_metadata(&root, &packet2, &hash2).unwrap();
+
+        collector.update().unwrap();
+        assert_eq!(collector.metadata_total.get(), 2);
+        assert_eq!(collector.packets_total.get(), 1);
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,21 +1,28 @@
 #[cfg(test)]
+#[macro_use]
 pub mod tests {
-    use crate::metadata::Packet;
+    use crate::hash::{hash_data, Hash, HashAlgorithm};
+    use crate::init::outpack_init;
+    use crate::metadata::{DependencyFile, Packet, PacketDependency, PacketFile, PacketTime};
+    use crate::utils::is_packet_str;
+    use crate::utils::time_as_num;
+
+    use rand::Rng;
     use std::collections::HashMap;
     use std::fs::File;
-    use std::hash::Hash;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
     use std::sync::Once;
+    use std::time::SystemTime;
     use tar::{Archive, Builder};
     use tempdir;
 
     pub fn vector_equals<T>(a: &[T], b: &[T]) -> bool
     where
-        T: Eq + Hash,
+        T: Eq + std::hash::Hash,
     {
         fn count<T>(items: &[T]) -> HashMap<&T, usize>
         where
-            T: Eq + Hash,
+            T: Eq + std::hash::Hash,
         {
             let mut cnt = HashMap::new();
             for i in items {
@@ -52,6 +59,121 @@ pub mod tests {
         let tmp_dir = tempdir::TempDir::new("outpack").expect("Temp dir created");
         let mut ar = Archive::new(File::open("example.tar").unwrap());
         ar.unpack(&tmp_dir).expect("unwrapped");
-        Path::new(&tmp_dir.into_path()).join("example")
+        tmp_dir.into_path().join("example")
+    }
+
+    pub fn get_empty_outpack_root() -> PathBuf {
+        let tmp_dir = tempdir::TempDir::new("outpack").expect("Temp dir created");
+
+        outpack_init(
+            tmp_dir.path().to_str().expect("valid path"),
+            None,
+            /* use_file_store */ true,
+            /* require_complete_tree */ true,
+        )
+        .unwrap();
+
+        tmp_dir.into_path()
+    }
+
+    pub fn random_id() -> String {
+        let now: chrono::DateTime<chrono::Utc> = SystemTime::now().into();
+
+        let fractional = now.timestamp_subsec_nanos() as f64 / 1e9;
+        let fractional = (fractional * u16::MAX as f64) as u16;
+
+        format!(
+            "{}-{:04x}{:04x}",
+            now.format("%Y%m%d-%H%M%S"),
+            fractional,
+            rand::thread_rng().gen::<u16>()
+        )
+    }
+
+    #[test]
+    fn random_id_format() {
+        let id = random_id();
+        assert!(is_packet_str(&id), "invalid packet id {}", id);
+    }
+
+    pub struct PacketBuilder {
+        packet: Packet,
+    }
+
+    /// Generate a new packet's metadata using a `PacketBuilder`.
+    pub fn start_packet(name: impl Into<String>) -> PacketBuilder {
+        PacketBuilder {
+            packet: Packet {
+                id: random_id(),
+                name: name.into(),
+                custom: None,
+                parameters: None,
+                files: Vec::new(),
+                depends: Vec::new(),
+                time: PacketTime {
+                    start: time_as_num(SystemTime::now()),
+                    end: 0.,
+                },
+            },
+        }
+    }
+
+    impl PacketBuilder {
+        pub fn add_file(
+            &mut self,
+            path: impl Into<String>,
+            hash: impl Into<String>,
+            size: usize,
+        ) -> &mut PacketBuilder {
+            self.packet.files.push(PacketFile {
+                path: path.into(),
+                hash: hash.into(),
+                size,
+            });
+            self
+        }
+
+        pub fn add_dependency(
+            &mut self,
+            packet: impl Into<String>,
+            files: impl Into<Vec<DependencyFile>>,
+        ) -> &mut PacketBuilder {
+            self.packet.depends.push(PacketDependency {
+                packet: packet.into(),
+                files: files.into(),
+            });
+            self
+        }
+
+        pub fn finish(&mut self) -> (String, String, Hash) {
+            self.packet.time.end = time_as_num(SystemTime::now());
+            let contents = serde_json::to_string(&self.packet).unwrap();
+            let hash = hash_data(contents.as_bytes(), HashAlgorithm::Sha256);
+            (self.packet.id.clone(), contents, hash)
+        }
+    }
+
+    pub use lazy_static::lazy_static;
+    pub use regex::Regex;
+    macro_rules! assert_regex {
+        ($lhs:expr, $pattern:literal) => {
+            // match trick comes from the std::assert_eq implementation. It extends
+            // the lifetime of any temporaries in lhs for the duration of the
+            // entire block.
+            match &$lhs {
+                lhs => {
+                    $crate::test_utils::tests::lazy_static! {
+                        static ref REGEX: $crate::test_utils::tests::Regex =
+                            $crate::test_utils::tests::Regex::new($pattern).unwrap();
+                    }
+                    assert!(
+                        REGEX.is_match(lhs.as_ref()),
+                        "{:?} does not match {:?}",
+                        lhs,
+                        $pattern
+                    );
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
These track the number of unpacked packets, the number of metadata files, the number of files in the store and the total byte size of those.

Here's an example of the generated metrics, after having pushed one packet to the server:

```
outpack_server_file_size_bytes_total 452
outpack_server_files_total 2
outpack_server_metadata_total 1
outpack_server_packets_total 1
```

Some other changes along the way:
- Added an API to generate packet metadata, for tests.
- `get_ids` used to take an `Option<bool>`, where `Some(false)` and `false` had the same semantics. Replaced with a plain `bool`.
- `put_file`'s argument is generalized to accept either a `TempFile` or a byte slice, making test code a bit more concise.
- Some tests were flaky because of a Rocket bug. I had fixed it upstream a while ago, but copy in the fix until that gets released.