### PR TITLE
Use Path/PathBuf for the repository root.

### DIFF
--- a/src/bin/outpack/args.rs
+++ b/src/bin/outpack/args.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 #[derive(clap::Parser, Debug)]
 pub struct Args {
     #[command(subcommand)]
@@ -8,7 +10,7 @@ pub struct Args {
 pub enum Command {
     /// Initialize a new outpack repository
     Init {
-        path: String,
+        path: PathBuf,
 
         /// Path to the archive in which packets are stored.
         #[arg(long)]
@@ -26,7 +28,7 @@ pub enum Command {
     /// Search for a packet in a repository
     Search {
         #[arg(short, long)]
-        root: String,
+        root: PathBuf,
         query: String,
     },
 
@@ -36,6 +38,6 @@ pub enum Command {
     /// Start the outpack API server
     StartServer {
         #[arg(short, long)]
-        root: String,
+        root: PathBuf,
     },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,16 +53,16 @@ impl Config {
     }
 }
 
-pub fn read_config(root_path: &str) -> Result<Config, Error> {
-    let path = Path::new(root_path).join(".outpack").join("config.json");
+pub fn read_config(root: &Path) -> Result<Config, Error> {
+    let path = root.join(".outpack").join("config.json");
     let config_file = fs::File::open(path)?;
     let config: Config = serde_json::from_reader(config_file)?;
     Ok(config)
 }
 
-pub fn write_config(config: &Config, root_path: &str) -> Result<(), Error> {
+pub fn write_config(config: &Config, root: &Path) -> Result<(), Error> {
     // assume .outpack exists
-    let path_config = Path::new(root_path).join(".outpack").join("config.json");
+    let path_config = root.join(".outpack").join("config.json");
     fs::File::create(&path_config)?;
     let json = serde_json::to_string(&config)?;
     fs::write(path_config, json)?;
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn can_read_config() {
-        let cfg = read_config("tests/example").unwrap();
+        let cfg = read_config(Path::new("tests/example")).unwrap();
         assert_eq!(cfg.core.hash_algorithm, HashAlgorithm::Sha256);
         assert!(cfg.core.use_file_store);
         assert!(cfg.core.require_complete_tree);
@@ -88,10 +88,9 @@ mod tests {
         let cfg = Config::new(None, true, true).unwrap();
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path();
-        let path_str = path.to_str().unwrap();
         fs::create_dir_all(path.join(".outpack")).unwrap();
-        write_config(&cfg, path_str).unwrap();
-        assert_eq!(read_config(path_str).unwrap(), cfg);
+        write_config(&cfg, path).unwrap();
+        assert_eq!(read_config(path).unwrap(), cfg);
     }
 
     #[test]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -310,7 +310,7 @@ mod tests {
             validate_hash_file(file.path(), unexpected),
             Err(HashError::new(HashErrorKind::HashesDontMatch,
                                String::from("Expected hash 'sha1:2ef7bde608ce5404e97d5f042f95f89f1c232872' but found 'sha1:2ef7bde608ce5404e97d5f042f95f89f1c232871'"))));
-        let res = validate_hash_file(file.path().join("more").as_path(), expected);
+        let res = validate_hash_file(&file.path().join("more"), expected);
         assert!(res.is_err());
         assert_eq!(res.unwrap_err().kind, HashErrorKind::FileReadFailed);
     }

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,13 +1,14 @@
 use crate::metadata::{get_metadata_from_date, Packet};
 use std::io;
+use std::path::Path;
 
 #[derive(Clone)]
 pub struct Index {
     pub packets: Vec<Packet>,
 }
 
-pub fn get_packet_index(root_path: &str) -> io::Result<Index> {
-    let packets = get_metadata_from_date(root_path, None)?;
+pub fn get_packet_index(root: &Path) -> io::Result<Index> {
+    let packets = get_metadata_from_date(root, None)?;
     Ok(Index { packets })
 }
 
@@ -17,7 +18,7 @@ mod tests {
 
     #[test]
     fn can_get_packet_index() {
-        let index = get_packet_index("tests/example").unwrap();
+        let index = get_packet_index(Path::new("tests/example")).unwrap();
         assert_eq!(index.packets.len(), 4);
         let ids: Vec<String> = index
             .packets

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -13,16 +13,18 @@ use crate::query::query_eval::eval_query;
 use crate::query::query_format::format_query_result;
 pub use crate::query::query_parse::parse_query;
 use crate::query::query_parse::Rule;
+use std::path::Path;
 
 use thiserror::Error;
 
-pub fn run_query(root: &str, query: &str) -> Result<String, QueryError> {
+pub fn run_query(root: &Path, query: &str) -> Result<String, QueryError> {
     let index = match get_packet_index(root) {
         Ok(index) => index,
         Err(e) => {
             return Err(QueryError::EvalError(format!(
                 "Could not build outpack index from root at {}: {:?}",
-                root, e
+                root.display(),
+                e
             )))
         }
     };

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -174,10 +174,11 @@ mod tests {
     use crate::test_utils::tests::assert_packet_ids_eq;
 
     use super::*;
+    use std::path::Path;
 
     #[test]
     fn query_lookup_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Test(
             TestOperator::Equal,
@@ -229,7 +230,7 @@ mod tests {
 
     #[test]
     fn query_latest_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Latest(None);
         let res = eval_query(&index, query).unwrap();
@@ -256,7 +257,7 @@ mod tests {
 
     #[test]
     fn can_get_parameter_as_literal() {
-        let packets = get_metadata_from_date("tests/example", None).unwrap();
+        let packets = get_metadata_from_date(Path::new("tests/example"), None).unwrap();
         assert_eq!(packets.len(), 4);
 
         let matching_packets: Vec<Packet> = packets
@@ -280,7 +281,7 @@ mod tests {
 
     #[test]
     fn can_test_lookup_filter() {
-        let packets = get_metadata_from_date("tests/example", None).unwrap();
+        let packets = get_metadata_from_date(Path::new("tests/example"), None).unwrap();
         assert_eq!(packets.len(), 4);
 
         let matching_packets: Vec<Packet> = packets
@@ -373,7 +374,7 @@ mod tests {
 
     #[test]
     fn can_use_different_test_types() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Test(
             TestOperator::Equal,
@@ -444,7 +445,7 @@ mod tests {
 
     #[test]
     fn invalid_comparisons_dont_match() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Test(
             TestOperator::GreaterThan,
@@ -493,7 +494,7 @@ mod tests {
 
     #[test]
     fn query_does_no_type_coersion() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Test(
             TestOperator::Equal,
@@ -527,7 +528,7 @@ mod tests {
 
     #[test]
     fn query_with_negation_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Negation(Box::new(QueryNode::Latest(None)));
         let res = eval_query(&index, query).unwrap();
@@ -549,7 +550,7 @@ mod tests {
 
     #[test]
     fn query_with_brackets_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Brackets(Box::new(QueryNode::Latest(None)));
         let res = eval_query(&index, query).unwrap();
@@ -577,7 +578,7 @@ mod tests {
 
     #[test]
     fn query_with_boolean_operators_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::BooleanExpr(
             BooleanOperator::Or,
@@ -609,7 +610,7 @@ mod tests {
 
     #[test]
     fn query_with_single_works() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
 
         let query = QueryNode::Single(Box::new(QueryNode::Latest(None)));
         let res = eval_query(&index, query).unwrap();
@@ -627,7 +628,7 @@ mod tests {
 
     #[test]
     fn query_with_this_fails() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
         let query = QueryNode::Test(
             TestOperator::Equal,
             TestValue::Lookup(Lookup::This("x")),
@@ -640,7 +641,7 @@ mod tests {
 
     #[test]
     fn query_with_environment_fails() {
-        let index = crate::index::get_packet_index("tests/example").unwrap();
+        let index = crate::index::get_packet_index(Path::new("tests/example")).unwrap();
         let query = QueryNode::Test(
             TestOperator::Equal,
             TestValue::Lookup(Lookup::Environment("x")),

--- a/src/query/query_format.rs
+++ b/src/query/query_format.rs
@@ -21,9 +21,12 @@ pub fn format_query_result(
 mod tests {
     use super::*;
 
+    use std::path::Path;
+
     #[test]
     fn query_result_can_be_formatted() {
-        let packets = crate::metadata::get_metadata_from_date("tests/example", None).unwrap();
+        let packets =
+            crate::metadata::get_metadata_from_date(Path::new("tests/example"), None).unwrap();
         let packet_refs: Vec<&Packet> = packets.iter().collect();
         let one_packet = vec![packet_refs[0]];
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -66,7 +66,7 @@ pub mod tests {
         let tmp_dir = tempdir::TempDir::new("outpack").expect("Temp dir created");
 
         outpack_init(
-            tmp_dir.path().to_str().expect("valid path"),
+            tmp_dir.path(),
             None,
             /* use_file_store */ true,
             /* require_complete_tree */ true,

--- a/tests/test_query.rs
+++ b/tests/test_query.rs
@@ -1,19 +1,20 @@
 use outpack::query::QueryError;
+use std::path::Path;
 
-pub fn test_query(root: &str, query: &str, result: &str) {
+pub fn test_query(root: &Path, query: &str, result: &str) {
     let packets = outpack::query::run_query(root, query).unwrap();
     assert_eq!(packets, result);
 }
 
 #[test]
 fn locates_latest_packet() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(root_path, "latest", "20180818-164043-7cdcde4b");
 }
 
 #[test]
 fn returns_parse_error_if_syntax_invalid() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     let e = outpack::query::run_query(root_path, "invalid").unwrap_err();
     assert!(matches!(e, outpack::query::QueryError::ParseError(..)));
     let text = format!("{}", e);
@@ -29,7 +30,7 @@ fn eval_error_can_be_displayed() {
 
 #[test]
 fn can_get_packet_by_id() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         r#"id == "20170818-164847-7574883b""#,
@@ -45,7 +46,7 @@ fn can_get_packet_by_id() {
 
 #[test]
 fn can_get_packet_by_name() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         r#"name == "modup-201707-queries1""#,
@@ -64,7 +65,7 @@ fn can_get_packet_by_name() {
 
 #[test]
 fn can_get_latest_of_lookup() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         r#"latest(name == "modup-201707-queries1")"#,
@@ -74,7 +75,7 @@ fn can_get_latest_of_lookup() {
 
 #[test]
 fn can_get_packet_by_parameter() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     let packets = outpack::query::run_query(root_path, r#"parameter:disease == "YF""#).unwrap();
     assert_eq!(
         packets,
@@ -95,7 +96,7 @@ fn can_get_packet_by_parameter() {
 
 #[test]
 fn can_get_packet_by_boolean_parameter() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         "parameter:pull_data == TRUE",
@@ -125,7 +126,7 @@ fn can_get_packet_by_boolean_parameter() {
 
 #[test]
 fn can_get_packet_by_numeric_parameter() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         "parameter:tolerance == 0.001",
@@ -171,7 +172,7 @@ fn can_get_packet_by_numeric_parameter() {
 
 #[test]
 fn no_packets_returned_incompatible_types() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(root_path, "id == 12345", "Found no packets");
     test_query(root_path, "id == true", "Found no packets");
     test_query(root_path, "name == true", "Found no packets");
@@ -179,7 +180,7 @@ fn no_packets_returned_incompatible_types() {
 
 #[test]
 fn can_get_packet_other_comparisons() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         "parameter:tolerance < 0.002",
@@ -217,7 +218,7 @@ fn can_get_packet_other_comparisons() {
 
 #[test]
 fn query_supports_groupings() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         r#"(name == "modup-201707-queries1")"#,
@@ -270,7 +271,7 @@ fn query_and_is_highest_precedence() {
     // This difference is clear if A is true, B is true and C is false
     // A || (B && C) -> TRUE
     // (A || B) && C -> FALSE
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
 
     test_query(
         root_path,
@@ -286,7 +287,7 @@ fn query_and_is_highest_precedence() {
 
 #[test]
 fn query_functions_can_be_nested() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
 
     test_query(
         root_path,
@@ -297,7 +298,7 @@ fn query_functions_can_be_nested() {
 
 #[test]
 fn query_can_assert_single_return() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         "single(parameter:pull_data == TRUE)",
@@ -313,7 +314,7 @@ fn query_can_assert_single_return() {
 
 #[test]
 fn comparisons_work_in_any_order_with_any_types() {
-    let root_path = "tests/example";
+    let root_path = Path::new("tests/example");
     test_query(
         root_path,
         "parameter:pull_data == TRUE",


### PR DESCRIPTION
Using strings requires verbose conversions to and from path types anytime we want to use path operations (ie. `join()` is the vast majority of cases).

Using the path types consistently everywhere means we never have to worry about conversions. We get a `PathBuf` straight from our command-line arguments and stick to it. The only exception is tests, which frequently use a string literal to point to the example repo. These string literals now need to be replaced with `Path::new(...)`.

This is a fairly large but mostly mechanical change. `String` is replaced by `PathBuf` and `&str` is replaced by `&Path`. Conversion code here and there gets removed.