### PR TITLE
Add a custom Python README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,15 +294,8 @@ The metadata should be written directly to the request body.
 
 ## Python bindings
 
-This crate provides Python bindings for its query parser. The bindings can be installed directly from PyPI using `pip install outpack_query_parser`.
-
-### Local development
-
-```
-hatch run python  # Start a Python interpreter with the bindings installed
-hatch run test    # Run the bindings test-suite
-hatch run develop # Rebuild the bindings. Necessary whenever changes to Rust code is made.
-```
+This crate provides Python bindings for its query parser. See
+[README.python.md] for details.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ The metadata should be written directly to the request body.
 ## Python bindings
 
 This crate provides Python bindings for its query parser. See
-[README.python.md] for details.
+[README.python.md](README.python.md) for details.
 
 ## Releasing
 

--- a/README.python.md
+++ b/README.python.md
@@ -1,0 +1,17 @@
+# outpack_query_parser
+
+Python bindings for the outpack query parser. The bindings can be installed
+directly from PyPI using `pip install outpack_query_parser`.
+
+This package provides a low-level building block for the Python version of
+outpack/orderly. Most users shouldn't need to use this package and should
+instead install [outpack-py](https://github.com/mrc-ide/outpack-py), which
+provides the high-level functionality.
+
+## Development
+
+```
+hatch run python  # Start a Python interpreter with the bindings installed
+hatch run test    # Run the bindings test-suite
+hatch run develop # Rebuild the bindings. Necessary whenever changes to Rust code is made.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "outpack_query_parser"
+readme = "README.python.md"
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]


### PR DESCRIPTION
By default Hatch automatically includes the README.md file at the root
of the project as the Python package's description, which shows up when
looking at the package on PyPI. Since the README mostly contains
information about the server this could lead to confusion, with users
trying to start a server when what they really wanted was to be
redirected to the main outpack-py package.

This adds a minimal README with the Python specific information, and a
link to the main package. The new file is referenced from
`pyproject.toml`, ensuring this is what gets used as the description
rather than the default one.