### PR TITLE
Use `--locked` when installing the server in the Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:latest as builder
 WORKDIR /usr/src/outpack_server
 COPY . .
-RUN cargo install --path .
+RUN cargo install --locked --path .
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Same problem we had in [the orderly2 CI][mrc-ide/orderly2#134]. By default `cargo install` ignores the lockfile and uses the latest compatible version of dependencies available on `crates.io`. Something changed in our dependency tree, and the build fails if the `Cargo.lock` isn't used, breaking our Docker image build.

Regardless of this particular failure, I think we should always be using the lockfile when assembling the Docker image. The lockfile represents the set of versions that were used when running the test suite, therefore this should be the versions we run in production. In a way we got lucky that this change broke the build, rather than cause a change in behaviour that might make the server misbehave in a way that the test suite would have caught.

[mrc-ide/orderly2#134]: https://github.com/mrc-ide/orderly2/pull/134