### PR TITLE
mrc-4973 Add list branches endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,13 @@ The metadata should be written directly to the request body.
 }
 ```
 
-### GET /git/fetch
+### POST /git/fetch
 
-Does a git fetch on the repository (relevant for when runners clone down git repositories)
+Does a git fetch on the repository (relevant for when runners clone down git repositories). Expects an empty json body.
 
 ### GET /git/branches
 
-Returns an array of branches with their `name`, `commit_hash` (where branch pointer is), `time` (of last commit) and `message` (of last commit)
+Returns an array of branches with their `name`, `commit_hash` (where branch pointer is), `time` (of last commit) and `message` (of last commit in a string array split with respect to newline characters)
 
 #### Response
 
@@ -310,13 +310,13 @@ Returns an array of branches with their `name`, `commit_hash` (where branch poin
       "name": "main",
       "commit_hash": "ede307e23b2137ba2c7c3270e52f354f224942af",
       "time": 1722436575,
-      "message": "First commit\n"
+      "message": ["First commit"]
     },
     {
       "name": "other",
       "commit_hash": "e9078cf779584168c3781379380a3b1352545cda",
       "time": 1722436640,
-      "message": "Second commit\n"
+      "message": ["Second commit"]
     }
   ],
   "errors": null

--- a/README.md
+++ b/README.md
@@ -292,6 +292,37 @@ The metadata should be written directly to the request body.
 }
 ```
 
+### GET /git/fetch
+
+Does a git fetch on the repository (relevant for when runners clone down git repositories)
+
+### GET /git/branches
+
+Returns an array of branches with their `name`, `commit_hash` (where branch pointer is), `time` (of last commit) and `message` (of last commit)
+
+#### Response
+
+```
+{
+  "status": "success",
+  "data": [
+    {
+      "name": "main",
+      "commit_hash": "ede307e23b2137ba2c7c3270e52f354f224942af",
+      "time": 1722436575,
+      "message": "First commit\n"
+    },
+    {
+      "name": "other",
+      "commit_hash": "e9078cf779584168c3781379380a3b1352545cda",
+      "time": 1722436640,
+      "message": "Second commit\n"
+    }
+  ],
+  "errors": null
+}
+```
+
 ## Python bindings
 
 This crate provides Python bindings for its query parser. See

--- a/schema/server/branch.json
+++ b/schema/server/branch.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "0.0.1",
+  "type": "object",
+  "properties": {
+    "name": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string" }
+      ]
+    },
+    "commit_hash": {
+      "type": "string"
+    },
+    "time": {
+      "type": "number"
+    },
+    "message": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string" }
+      ]
+    }
+  },
+  "required": ["name", "commit_hash", "time", "message"],
+  "additionalProperties": false
+}

--- a/schema/server/branch.json
+++ b/schema/server/branch.json
@@ -4,10 +4,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "string" }
-      ]
+      "type": ["null", "string"]
     },
     "commit_hash": {
       "type": "string"
@@ -18,7 +15,12 @@
     "message": {
       "oneOf": [
         { "type": "null" },
-        { "type": "string" }
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
       ]
     }
   },

--- a/schema/server/branch.json
+++ b/schema/server/branch.json
@@ -4,7 +4,7 @@
   "type": "object",
   "properties": {
     "name": {
-      "type": ["null", "string"]
+      "type": "string"
     },
     "commit_hash": {
       "type": "string"
@@ -13,15 +13,10 @@
       "type": "number"
     },
     "message": {
-      "oneOf": [
-        { "type": "null" },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     }
   },
   "required": ["name", "commit_hash", "time", "message"],

--- a/schema/server/branches.json
+++ b/schema/server/branches.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "version": "0.0.1",
+  "type": "array",
+  "items": {
+    "$ref": "branch.json"
+  }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -164,7 +164,9 @@ async fn git_fetch(root: State<PathBuf>) -> Result<OutpackSuccess<()>, OutpackEr
         .map(OutpackSuccess::from)
 }
 
-async fn git_list_branches(root: State<PathBuf>) -> Result<OutpackSuccess<Vec<git::BranchInfo>>, OutpackError> {
+async fn git_list_branches(
+    root: State<PathBuf>,
+) -> Result<OutpackSuccess<Vec<git::BranchInfo>>, OutpackError> {
     git::git_list_branches(&root)
         .map_err(OutpackError::from)
         .map(OutpackSuccess::from)

--- a/src/api.rs
+++ b/src/api.rs
@@ -164,6 +164,12 @@ async fn git_fetch(root: State<PathBuf>) -> Result<OutpackSuccess<()>, OutpackEr
         .map(OutpackSuccess::from)
 }
 
+async fn git_list_branches(root: State<PathBuf>) -> Result<OutpackSuccess<Vec<git::BranchInfo>>, OutpackError> {
+    git::git_list_branches(&root)
+        .map_err(OutpackError::from)
+        .map(OutpackSuccess::from)
+}
+
 #[derive(Serialize, Deserialize)]
 struct Ids {
     ids: Vec<String>,
@@ -245,6 +251,7 @@ pub fn api(root: &Path) -> anyhow::Result<Router> {
         .route("/file/:hash", get(get_file).post(add_file))
         .route("/packet/:hash", post(add_packet))
         .route("/git/fetch", post(git_fetch))
+        .route("/git/branches", post(git_list_branches))
         .route("/metrics", get(|| async move { metrics::render(registry) }))
         .fallback(not_found)
         .with_state(root.to_owned());

--- a/src/api.rs
+++ b/src/api.rs
@@ -252,7 +252,7 @@ pub fn api(root: &Path) -> anyhow::Result<Router> {
         .route("/packit/metadata", get(get_metadata_since))
         .route("/file/:hash", get(get_file).post(add_file))
         .route("/packet/:hash", post(add_packet))
-        .route("/git/fetch", get(git_fetch))
+        .route("/git/fetch", post(git_fetch))
         .route("/git/branches", get(git_list_branches))
         .route("/metrics", get(|| async move { metrics::render(registry) }))
         .fallback(not_found)

--- a/src/api.rs
+++ b/src/api.rs
@@ -250,8 +250,8 @@ pub fn api(root: &Path) -> anyhow::Result<Router> {
         .route("/packit/metadata", get(get_metadata_since))
         .route("/file/:hash", get(get_file).post(add_file))
         .route("/packet/:hash", post(add_packet))
-        .route("/git/fetch", post(git_fetch))
-        .route("/git/branches", post(git_list_branches))
+        .route("/git/fetch", get(git_fetch))
+        .route("/git/branches", get(git_list_branches))
         .route("/metrics", get(|| async move { metrics::render(registry) }))
         .fallback(not_found)
         .with_state(root.to_owned());

--- a/src/git.rs
+++ b/src/git.rs
@@ -95,16 +95,10 @@ mod tests {
         let test_git = initialise_git_repo(None);
         git_fetch(&test_git.dir.path().join("local")).unwrap();
         let branches = git_list_branches(&test_git.dir.path().join("local")).unwrap();
-        let now_in_seconds = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].name, String::from("master"));
         assert_eq!(branches[0].message, vec![String::from("Second commit")]);
-        assert_eq!(branches[0].time, now_in_seconds as i64);
         assert_eq!(branches[1].name, String::from("other"));
         assert_eq!(branches[1].message, vec![String::from("Third commit")]);
-        assert_eq!(branches[1].time, now_in_seconds as i64);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -89,7 +89,7 @@ mod tests {
             .unwrap()
             .as_secs();
         assert_eq!(branches.len(), 2);
-        assert_eq!(branches[0].name, Some(String::from("main")));
+        assert_eq!(branches[0].name, Some(String::from("master")));
         assert_eq!(branches[0].message, Some(String::from("Second commit")));
         assert_eq!(branches[0].time, now_in_seconds as i64);
         assert_eq!(branches[1].name, Some(String::from("other")));

--- a/src/git.rs
+++ b/src/git.rs
@@ -92,10 +92,16 @@ mod tests {
             .as_secs();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].name, Some(String::from("master")));
-        assert_eq!(branches[0].message, Some(vec![String::from("Second commit")]));
+        assert_eq!(
+            branches[0].message,
+            Some(vec![String::from("Second commit")])
+        );
         assert_eq!(branches[0].time, now_in_seconds as i64);
         assert_eq!(branches[1].name, Some(String::from("other")));
-        assert_eq!(branches[1].message, Some(vec![String::from("Third commit")]));
+        assert_eq!(
+            branches[1].message,
+            Some(vec![String::from("Third commit")])
+        );
         assert_eq!(branches[1].time, now_in_seconds as i64);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,7 +17,7 @@ pub struct BranchInfo {
     name: Option<String>,
     commit_hash: String,
     time: i64,
-    message: Option<String>,
+    message: Option<Vec<String>>,
 }
 
 fn get_branch_info(
@@ -27,7 +27,9 @@ fn get_branch_info(
     let name = branch.name()?.map(String::from);
 
     let branch_commit = branch.into_reference().peel_to_commit()?;
-    let message = branch_commit.message().map(String::from);
+    let message = branch_commit
+        .message()
+        .map(|s| s.split("\n").map(String::from).collect::<Vec<String>>());
 
     Ok(BranchInfo {
         name,
@@ -90,10 +92,10 @@ mod tests {
             .as_secs();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].name, Some(String::from("master")));
-        assert_eq!(branches[0].message, Some(String::from("Second commit")));
+        assert_eq!(branches[0].message, Some(vec![String::from("Second commit")]));
         assert_eq!(branches[0].time, now_in_seconds as i64);
         assert_eq!(branches[1].name, Some(String::from("other")));
-        assert_eq!(branches[1].message, Some(String::from("Third commit")));
+        assert_eq!(branches[1].message, Some(vec![String::from("Third commit")]));
         assert_eq!(branches[1].time, now_in_seconds as i64);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -58,8 +58,6 @@ pub fn git_list_branches(root: &Path) -> Result<Vec<BranchInfo>, git2::Error> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::SystemTime;
-
     use test_utils::{git_get_latest_commit, git_remote_branches, initialise_git_repo};
 
     use super::*;

--- a/src/git.rs
+++ b/src/git.rs
@@ -20,7 +20,9 @@ pub struct BranchInfo {
     message: Option<String>,
 }
 
-fn get_branch_info(branch_struct: Result<(Branch, BranchType), git2::Error>) -> Result<BranchInfo, git2::Error> {
+fn get_branch_info(
+    branch_struct: Result<(Branch, BranchType), git2::Error>,
+) -> Result<BranchInfo, git2::Error> {
     let branch = branch_struct?.0;
     let name = branch.name()?.map(String::from);
 
@@ -37,10 +39,11 @@ fn get_branch_info(branch_struct: Result<(Branch, BranchType), git2::Error>) -> 
 
 pub fn git_list_branches(root: &Path) -> Result<Vec<BranchInfo>, git2::Error> {
     let repo = Repository::open(root)?;
-    let branches = repo.branches(Some(BranchType::Local))?
+    let git_branches: Result<Vec<BranchInfo>, git2::Error> = repo
+        .branches(Some(BranchType::Local))?
         .map(get_branch_info)
         .collect();
-    Ok(branches)
+    git_branches
 }
 
 #[cfg(test)]
@@ -86,11 +89,11 @@ mod tests {
             .unwrap()
             .as_secs();
         assert_eq!(branches.len(), 2);
-        assert_eq!(branches[0].name, "master");
-        assert_eq!(branches[0].message, "Second commit");
+        assert_eq!(branches[0].name, Some(String::from("main")));
+        assert_eq!(branches[0].message, Some(String::from("Second commit")));
         assert_eq!(branches[0].time, now_in_seconds as i64);
-        assert_eq!(branches[1].name, "other");
-        assert_eq!(branches[1].message, "Third commit");
+        assert_eq!(branches[1].name, Some(String::from("other")));
+        assert_eq!(branches[1].message, Some(String::from("Third commit")));
         assert_eq!(branches[1].time, now_in_seconds as i64);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -27,9 +27,11 @@ fn get_branch_info(
     let name = branch.name()?.map(String::from);
 
     let branch_commit = branch.into_reference().peel_to_commit()?;
-    let message = branch_commit
-        .message()
-        .map(|s| s.split("\n").map(String::from).collect::<Vec<String>>());
+    let message = branch_commit.message().map(|s| {
+        s.split_terminator("\n")
+            .map(String::from)
+            .collect::<Vec<String>>()
+    });
 
     Ok(BranchInfo {
         name,

--- a/src/git.rs
+++ b/src/git.rs
@@ -14,24 +14,27 @@ pub fn git_fetch(root: &Path) -> Result<(), git2::Error> {
 
 #[derive(Serialize, Deserialize)]
 pub struct BranchInfo {
-    name: Option<String>,
+    name: String,
     commit_hash: String,
     time: i64,
-    message: Option<Vec<String>>,
+    message: Vec<String>,
 }
 
 fn get_branch_info(
     branch_struct: Result<(Branch, BranchType), git2::Error>,
 ) -> Result<BranchInfo, git2::Error> {
     let branch = branch_struct?.0;
-    let name = branch.name()?.map(String::from);
+    let lossy_name = String::from_utf8_lossy(branch.name_bytes()?);
+    let name = lossy_name
+        .strip_prefix("origin/")
+        .unwrap_or(&lossy_name)
+        .to_owned();
 
     let branch_commit = branch.into_reference().peel_to_commit()?;
-    let message = branch_commit.message().map(|s| {
-        s.split_terminator("\n")
-            .map(String::from)
-            .collect::<Vec<String>>()
-    });
+    let message: Vec<String> = String::from_utf8_lossy(branch_commit.message_bytes())
+        .split_terminator("\n")
+        .map(String::from)
+        .collect();
 
     Ok(BranchInfo {
         name,
@@ -44,7 +47,10 @@ fn get_branch_info(
 pub fn git_list_branches(root: &Path) -> Result<Vec<BranchInfo>, git2::Error> {
     let repo = Repository::open(root)?;
     let git_branches: Result<Vec<BranchInfo>, git2::Error> = repo
-        .branches(Some(BranchType::Local))?
+        .branches(Some(BranchType::Remote))?
+        // first branch seems to be HEAD, we don't want to display that to the
+        // users so skip it
+        .skip(1)
         .map(get_branch_info)
         .collect();
     git_branches
@@ -87,23 +93,18 @@ mod tests {
     #[test]
     fn can_list_git_branches() {
         let test_git = initialise_git_repo(None);
-        let branches = git_list_branches(&test_git.dir.path().join("remote")).unwrap();
+        git_fetch(&test_git.dir.path().join("local")).unwrap();
+        let branches = git_list_branches(&test_git.dir.path().join("local")).unwrap();
         let now_in_seconds = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs();
         assert_eq!(branches.len(), 2);
-        assert_eq!(branches[0].name, Some(String::from("master")));
-        assert_eq!(
-            branches[0].message,
-            Some(vec![String::from("Second commit")])
-        );
+        assert_eq!(branches[0].name, String::from("master"));
+        assert_eq!(branches[0].message, vec![String::from("Second commit")]);
         assert_eq!(branches[0].time, now_in_seconds as i64);
-        assert_eq!(branches[1].name, Some(String::from("other")));
-        assert_eq!(
-            branches[1].message,
-            Some(vec![String::from("Third commit")])
-        );
+        assert_eq!(branches[1].name, String::from("other"));
+        assert_eq!(branches[1].message, vec![String::from("Third commit")]);
         assert_eq!(branches[1].time, now_in_seconds as i64);
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -48,9 +48,12 @@ pub fn git_list_branches(root: &Path) -> Result<Vec<BranchInfo>, git2::Error> {
     let repo = Repository::open(root)?;
     let git_branches: Result<Vec<BranchInfo>, git2::Error> = repo
         .branches(Some(BranchType::Remote))?
-        // first branch seems to be HEAD, we don't want to display that to the
-        // users so skip it
-        .skip(1)
+        .filter(|branch_tuple| -> bool {
+            if let Ok((b, _)) = branch_tuple {
+                return b.name() != Ok(Some("origin/HEAD"));
+            }
+            true
+        })
         .map(get_branch_info)
         .collect();
     git_branches

--- a/src/git.rs
+++ b/src/git.rs
@@ -17,24 +17,25 @@ pub struct BranchInfo {
     name: String,
     commit_hash: String,
     time: i64,
-    message: String
+    message: String,
 }
 
 pub fn git_list_branches(root: &Path) -> Result<Vec<BranchInfo>, git2::Error> {
     let repo = Repository::open(root)?;
-    let branches = repo.branches(Some(BranchType::Local))?
+    let branches = repo
+        .branches(Some(BranchType::Local))?
         .map(|branch| branch.unwrap().0)
         .map(|branch_struct| -> BranchInfo {
-                let name = branch_struct.name().unwrap().unwrap().to_owned();
-                let branch_commit = branch_struct.into_reference().peel_to_commit().unwrap();
-                BranchInfo {
-                    name,
-                    commit_hash: branch_commit.id().to_string(),
-                    time: branch_commit.time().seconds(),
-                    message: branch_commit.message().unwrap().to_owned()
-                }
-                // branch_struct.into_reference().peel_to_commit().unwrap().
-            })
+            let name = branch_struct.name().unwrap().unwrap().to_owned();
+            let branch_commit = branch_struct.into_reference().peel_to_commit().unwrap();
+            BranchInfo {
+                name,
+                commit_hash: branch_commit.id().to_string(),
+                time: branch_commit.time().seconds(),
+                message: branch_commit.message().unwrap().to_owned(),
+            }
+            // branch_struct.into_reference().peel_to_commit().unwrap().
+        })
         .collect();
     Ok(branches)
 }
@@ -77,7 +78,10 @@ mod tests {
     fn can_list_git_branches() {
         let test_git = initialise_git_repo(None);
         let branches = git_list_branches(&test_git.dir.path().join("remote")).unwrap();
-        let now_in_seconds = SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_secs();
+        let now_in_seconds = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
         assert_eq!(branches.len(), 2);
         assert_eq!(branches[0].name, "master");
         assert_eq!(branches[0].message, "Second commit");

--- a/start-with-wait
+++ b/start-with-wait
@@ -15,5 +15,10 @@ do
         attempt_num=$((attempt_num++))
     fi
 done
+
+# git2 errors as the git repository mounted is not owned by
+# us, we need to declare it a safe directory to ignore ownership
+git config --global --add safe.directory /outpack
+
 echo "Found outpack root; starting server"
 outpack start-server --root /outpack

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -780,7 +780,13 @@ async fn can_list_git_branches() {
         .unwrap()
         .as_secs();
 
-    let mut client = TestClient::new(test_git.dir.path().join("remote"));
+    let mut client = TestClient::new(test_git.dir.path().join("local"));
+
+    let response_fetch = client
+        .post("/git/fetch", mime::APPLICATION_JSON, Body::empty())
+        .await;
+    assert_eq!(response_fetch.status(), StatusCode::OK);
+    assert_eq!(response_fetch.content_type(), mime::APPLICATION_JSON);
 
     let response = client.get("/git/branches").await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -747,7 +747,9 @@ async fn can_fetch_git() {
     let initial_branches = git_remote_branches(&test_git.local);
     assert_eq!(initial_branches.count(), 2); // HEAD and main
 
-    let response = client.get("/git/fetch").await;
+    let response = client
+    .post("/git/fetch", mime::APPLICATION_JSON, Body::empty())
+    .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.content_type(), mime::APPLICATION_JSON);
 
@@ -795,8 +797,8 @@ async fn can_list_git_branches() {
         now_in_seconds
     );
     assert_eq!(
-        entries[0].get("message").unwrap().as_str().unwrap(),
-        "Second commit"
+        *entries[0].get("message").unwrap().as_array().unwrap(),
+        vec!["Second commit"]
     );
     assert_eq!(entries[1].get("name").unwrap().as_str().unwrap(), "other");
     assert_eq!(
@@ -804,8 +806,8 @@ async fn can_list_git_branches() {
         now_in_seconds
     );
     assert_eq!(
-        entries[1].get("message").unwrap().as_str().unwrap(),
-        "Third commit"
+        *entries[1].get("message").unwrap().as_array().unwrap(),
+        vec!["Third commit"]
     );
 }
 

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -3,7 +3,6 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Once;
-use std::time::SystemTime;
 
 use axum::body::Body;
 use axum::extract::Request;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -747,9 +747,7 @@ async fn can_fetch_git() {
     let initial_branches = git_remote_branches(&test_git.local);
     assert_eq!(initial_branches.count(), 2); // HEAD and main
 
-    let response = client
-        .get("/git/fetch")
-        .await;
+    let response = client.get("/git/fetch").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.content_type(), mime::APPLICATION_JSON);
 
@@ -776,15 +774,13 @@ async fn can_list_git_branches() {
     let test_dir = get_test_dir();
     let test_git = initialise_git_repo(Some(&test_dir));
     let now_in_seconds = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
 
     let mut client = TestClient::new(test_git.dir.path().join("remote"));
 
-    let response = client
-        .get("/git/branches")
-        .await;
+    let response = client.get("/git/branches").await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.content_type(), mime::APPLICATION_JSON);
 
@@ -793,10 +789,7 @@ async fn can_list_git_branches() {
 
     let entries = body.get("data").unwrap().as_array().unwrap();
 
-    assert_eq!(
-        entries[0].get("name").unwrap().as_str().unwrap(),
-        "master"
-    );
+    assert_eq!(entries[0].get("name").unwrap().as_str().unwrap(), "master");
     assert_eq!(
         entries[0].get("time").unwrap().as_u64().unwrap(),
         now_in_seconds
@@ -805,10 +798,7 @@ async fn can_list_git_branches() {
         entries[0].get("message").unwrap().as_str().unwrap(),
         "Second commit"
     );
-    assert_eq!(
-        entries[1].get("name").unwrap().as_str().unwrap(),
-        "other"
-    );
+    assert_eq!(entries[1].get("name").unwrap().as_str().unwrap(), "other");
     assert_eq!(
         entries[1].get("time").unwrap().as_u64().unwrap(),
         now_in_seconds

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -775,10 +775,6 @@ async fn can_fetch_git() {
 async fn can_list_git_branches() {
     let test_dir = get_test_dir();
     let test_git = initialise_git_repo(Some(&test_dir));
-    let now_in_seconds = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
 
     let mut client = TestClient::new(test_git.dir.path().join("local"));
 
@@ -799,18 +795,10 @@ async fn can_list_git_branches() {
 
     assert_eq!(entries[0].get("name").unwrap().as_str().unwrap(), "master");
     assert_eq!(
-        entries[0].get("time").unwrap().as_u64().unwrap(),
-        now_in_seconds
-    );
-    assert_eq!(
         *entries[0].get("message").unwrap().as_array().unwrap(),
         vec!["Second commit"]
     );
     assert_eq!(entries[1].get("name").unwrap().as_str().unwrap(), "other");
-    assert_eq!(
-        entries[1].get("time").unwrap().as_u64().unwrap(),
-        now_in_seconds
-    );
     assert_eq!(
         *entries[1].get("message").unwrap().as_array().unwrap(),
         vec!["Third commit"]

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -748,8 +748,8 @@ async fn can_fetch_git() {
     assert_eq!(initial_branches.count(), 2); // HEAD and main
 
     let response = client
-    .post("/git/fetch", mime::APPLICATION_JSON, Body::empty())
-    .await;
+        .post("/git/fetch", mime::APPLICATION_JSON, Body::empty())
+        .await;
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.content_type(), mime::APPLICATION_JSON);
 


### PR DESCRIPTION
This should add a get endpoint `/git/branches` to get information about the available branches. Main changes include:
* added git fetch and git branches endpoints to the README
* added `git_list_branches` function
* changed `git/fetch` endpoint to a get instead of a post, made more sense to me
* had to add `git config --global --add safe.directory /outpack` to `start-with-wait` because git was complaining about not being the owner of the repository

To test this manually, you can go to `/outpack` in the docker container and make some git branches or you can just mount a git repo into `/outpack` and then `curl localhost:8000/git/branches`

Note the original ticket also suggested having a boolean to show if the branch had unmerged commits or not, i could not find a super easy way to do this in rust (old logic for this was written in orderly.server in R by shelling out) so i have left it as a separate ticket: https://mrc-ide.myjetbrains.com/youtrack/issue/mrc-5579/Add-key-to-determine-which-branch-has-unmerged-commits