### PR TITLE
Add a streaming hash implementation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,10 +1179,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "md5"
-version = "0.7.0"
+name = "md-5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1408,12 +1412,13 @@ dependencies = [
  "cached",
  "chrono",
  "clap",
+ "digest",
  "futures",
  "git2",
  "itertools",
  "jsonschema",
  "lazy_static",
- "md5",
+ "md-5",
  "mime",
  "pest",
  "pest_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 cached = "0.40.0"
 walkdir = "2.3.2"
-md5 = "0.7.0"
 sha2 = "0.10.6"
 sha1 = "0.10.5"
 lazy_static = "1.4.0"
@@ -36,6 +35,8 @@ futures = "0.3.30"
 tower = "0.4.13"
 mime = "0.3.17"
 git2 = { version = "0.18.2" }
+digest = "0.10.7"
+md-5 = "0.10.6"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/src/api.rs
+++ b/src/api.rs
@@ -141,10 +141,13 @@ async fn add_file(
     hash: extract::Path<String>,
     file: Upload,
 ) -> Result<OutpackSuccess<()>, OutpackError> {
-    store::put_file(&root, file, &hash)
-        .await
-        .map_err(OutpackError::from)
-        .map(OutpackSuccess::from)
+    tokio::task::spawn_blocking(move || {
+        store::put_file(&root, file, &hash)
+            .map_err(OutpackError::from)
+            .map(OutpackSuccess::from)
+    })
+    .await
+    .unwrap()
 }
 
 async fn add_packet(
@@ -159,17 +162,25 @@ async fn add_packet(
 }
 
 async fn git_fetch(root: State<PathBuf>) -> Result<OutpackSuccess<()>, OutpackError> {
-    git::git_fetch(&root)
-        .map_err(OutpackError::from)
-        .map(OutpackSuccess::from)
+    tokio::task::spawn_blocking(move || {
+        git::git_fetch(&root)
+            .map_err(OutpackError::from)
+            .map(OutpackSuccess::from)
+    })
+    .await
+    .unwrap()
 }
 
 async fn git_list_branches(
     root: State<PathBuf>,
 ) -> Result<OutpackSuccess<git::BranchResponse>, OutpackError> {
-    git::git_list_branches(&root)
-        .map_err(OutpackError::from)
-        .map(OutpackSuccess::from)
+    tokio::task::spawn_blocking(move || {
+        git::git_list_branches(&root)
+            .map_err(OutpackError::from)
+            .map(OutpackSuccess::from)
+    })
+    .await
+    .unwrap()
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -289,6 +289,7 @@ mod tests {
     use crate::store::file_exists;
     use crate::test_utils::tests::{get_temp_outpack_root, start_packet};
     use crate::utils::time_as_num;
+    use md5::Md5;
     use serde_json::Value;
     use sha2::{Digest, Sha256};
 
@@ -336,7 +337,7 @@ mod tests {
         let digest = get_ids_digest(Path::new("tests/example"), None).unwrap();
         let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180220-095832-16a4bbed\
         20180818-164043-7cdcde4b";
-        let expected = format!("sha256:{:x}", Sha256::new().chain_update(dat).finalize());
+        let expected = format!("sha256:{:x}", Sha256::digest(dat));
         assert_eq!(digest, expected);
     }
 
@@ -345,7 +346,7 @@ mod tests {
         let digest = get_ids_digest(Path::new("tests/example"), Some(String::from("md5"))).unwrap();
         let dat = "20170818-164830-33e0ab0120170818-164847-7574883b20180220-095832-16a4bbed\
         20180818-164043-7cdcde4b";
-        let expected = format!("md5:{:x}", md5::compute(dat));
+        let expected = format!("md5:{:x}", Md5::digest(dat));
         assert_eq!(digest, expected);
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -264,8 +264,8 @@ mod tests {
 
         let total_size = data1.len() + data2.len();
 
-        put_file(&root, data1, &hash1).await.unwrap();
-        put_file(&root, data2, &hash2).await.unwrap();
+        put_file(&root, data1, &hash1).unwrap();
+        put_file(&root, data2, &hash2).unwrap();
 
         collector.update().unwrap();
         assert_eq!(collector.files_total.get(), 2);

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -53,14 +53,13 @@ impl Upload {
     ///
     /// The file is moved to the destination path. That path must be located on the same filesystem
     /// as the configured upload directory.
-    pub async fn persist(self, destination: &Path) -> std::io::Result<()> {
+    pub fn persist(self, destination: &Path) -> std::io::Result<()> {
         match self {
             Upload::Buffered(data) => {
-                tokio::fs::write(destination, &data).await?;
+                std::fs::write(destination, &data)?;
             }
             Upload::File(path) => {
-                let destination = destination.to_owned();
-                tokio::task::spawn_blocking(move || path.persist(destination).unwrap()).await?
+                path.persist(destination)?;
             }
         }
         Ok(())
@@ -156,7 +155,7 @@ mod tests {
         }
 
         let destination = root.as_ref().join("hello.txt");
-        upload.persist(&destination).await.unwrap();
+        upload.persist(&destination).unwrap();
 
         let contents = tokio::fs::read(&destination).await.unwrap();
         assert_eq!(contents, data);

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -56,7 +56,7 @@ impl Upload {
     pub fn persist(self, destination: &Path) -> std::io::Result<()> {
         match self {
             Upload::Buffered(data) => {
-                std::fs::write(destination, &data)?;
+                std::fs::write(destination, data)?;
             }
             Upload::File(path) => {
                 path.persist(destination)?;

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -553,10 +553,7 @@ async fn missing_files_validates_request_body() {
 async fn can_post_file() {
     let mut client = get_default_client();
     let content = "test";
-    let hash = format!(
-        "sha256:{:x}",
-        Sha256::new().chain_update(content).finalize()
-    );
+    let hash = format!("sha256:{:x}", Sha256::digest(content));
     let response = client
         .post(
             format!("/file/{}", hash),
@@ -618,10 +615,7 @@ async fn can_post_metadata() {
                                 "orderly.R"
                               ]
                             }"#;
-    let hash = format!(
-        "sha256:{:x}",
-        Sha256::new().chain_update(content).finalize()
-    );
+    let hash = format!("sha256:{:x}", Sha256::digest(content));
     let response = client
         .post(format!("/packet/{}", hash), mime::TEXT_PLAIN_UTF_8, content)
         .await;


### PR DESCRIPTION
Previously files were being hashed by loading them in memory entirely first, then hashing the resulting buffer. When uploading large files, this puts a lot of memory pressure on the server.

Thankfully the hash types provide `io::Write`, meaning implementing a streaming hash is as straightforward as using `io::copy` from the input into them.

A few adjecent changes, mostly about wrapping some code behind a `spawn_blocking` call; a lot of our implementation is synchronous, and calling it directly from the main thread could cause it to block. The biggest offenders were the aforementioned hashing, and git operations.