### PR TITLE
Correct the documentation of the packit/metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,14 +121,20 @@ e.g. `/packit/metadata?known_since=1683117048`.
         {
             "id": "20220812-155808-c873e405",
             "name": "depends",
-            "custom": { "orderly": { "display": "Report with dependencies" }}
-            "parameters": null
+            "parameters": null,
+            "time": {
+              "start": 1722268521.089,
+              "end": 1722268521.1252
+            }
         },
         {
             "id": "20220812-155808-d5747caf",
             "name": "params",
-            "custom": { "orderly": { "display": "Report with parameters" }},
-            "parameters": { "alpha": 1 }
+            "parameters": { "alpha": 1 },
+            "time": {
+              "start": 1724957680.4807,
+              "end": 1724957680.6728
+            }
         }
     ]
 }


### PR DESCRIPTION
Here is the start of a response I got:

```
curl -s http://localhost:8000/packit/metadata | jq

{
  "status": "success",
  "data": [
    {
      "id": "20240729-154633-10abe7d1",
      "name": "artefact-types",
      "parameters": null,
      "time": {
        "start": 1722267993.0676,
        "end": 1722267993.0971
      }
    },
    {
      "id": "20240729-154635-88c5c1eb",
      "name": "computed-resource",
      "parameters": null,
      "time": {
        "start": 1722267995.5361,
        "end": 1722267995.5652
      }
    },
 ```
 
 Not sure if this is documented elsewhere too