### PR TITLE
Add custom metadata to /packit/metadata endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run all tests with `cargo test`.
 ## API
 ### GET /
 
-```
+```json
 {
    "status": "succcess",
    "data": {
@@ -66,17 +66,17 @@ Returns hash of all current packet ids, ordered alphanumerically and concatenate
 in the `outpack` config, unless a query parameter specifying an alternative is passed: 
 e.g. `/checksum?alg=md5`. 
 
-```
+```json
 {
    "status": "succcess",
-   "data": "md5:117723186364b4b409081b1bd347d406"
+   "data": "md5:117723186364b4b409081b1bd347d406",
    "errors": null
 }
 ```
 
 ### GET /metadata/list
 
-```
+```json
 {
     "status": "success",
     "errors": null,
@@ -113,7 +113,7 @@ from which to return results. This will filter packets by the `time` property of
 location metadata, i.e. the point at which they were inserted into the index.
 e.g. `/packit/metadata?known_since=1683117048`. 
 
-```
+```json
 {
     "status": "success",
     "errors": null,
@@ -121,14 +121,22 @@ e.g. `/packit/metadata?known_since=1683117048`.
         {
             "id": "20220812-155808-c873e405",
             "name": "depends",
-            "custom": { "orderly": { "display": "Report with dependencies" }}
-            "parameters": null
+            "parameters": null,
+            "time": {
+              "end": 1503074545.8687,
+              "start": 1503074545.8687
+            },
+            "custom": { "orderly": { "description": { "display": "Report with dependencies" }}},
         },
         {
             "id": "20220812-155808-d5747caf",
             "name": "params",
-            "custom": { "orderly": { "display": "Report with parameters" }},
-            "parameters": { "alpha": 1 }
+            "parameters": { "alpha": 1 },
+            "time": {
+              "start": 1722267993.0676,
+              "end": 1722267993.0971
+            },
+            "custom": { "orderly": { "description": { "display": "Report with parameters" }}},
         }
     ]
 }
@@ -137,7 +145,7 @@ e.g. `/packit/metadata?known_since=1683117048`.
 
 ### GET /metadata/\<id\>/json
 
-```
+```json
 {
   "status": "success",
   "errors": null,
@@ -223,7 +231,7 @@ Given a list of ids, returns those that are missing in the current root. If `unp
 returns missing unpacked packets, otherwise just looks at missing metadata. 
 
 #### Response
-```
+```json
 {
   "status": "success",
   "errors": null,
@@ -246,7 +254,7 @@ returns missing unpacked packets, otherwise just looks at missing metadata.
 Given a list of file hashes, returns those that are missing in the current root.
 
 #### Response
-```
+```json
 {
   "status": "success",
   "errors": null,
@@ -265,7 +273,7 @@ The file contents should be written directly to the request body.
 
 #### Response
 
-```
+```json
 {
   "status": "success",
   "errors": null,
@@ -284,7 +292,7 @@ The metadata should be written directly to the request body.
 
 #### Response
 
-```
+```json
 {
   "status": "success",
   "errors": null,
@@ -302,7 +310,7 @@ Returns an array of branches with their `name`, `commit_hash` (where branch poin
 
 #### Response
 
-```
+```json
 {
     "status": "success",
     "data": {

--- a/schema/server/list.json
+++ b/schema/server/list.json
@@ -17,6 +17,7 @@
                 "description": "Task parameters, used when running and for querying",
                 "type": ["null", "object"]
             },
+
             "time": {
                 "description": "Information about the running time",
                 "start": {
@@ -27,6 +28,11 @@
                     "description": "Time that the report was completed, in seconds since 1970-01-01",
                     "type": "number"
                 }
+            },
+
+            "custom": {
+                "description": "Optional custom metadata, grouped under application keys",
+                "type": ["null", "object"]
             }
         },
         "required": ["id", "name"],

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -19,6 +19,7 @@ pub struct PackitPacket {
     pub name: String,
     pub parameters: Option<HashMap<String, serde_json::Value>>,
     pub time: PacketTime,
+    pub custom: Option<serde_json::Value>,
 }
 
 impl PackitPacket {
@@ -28,6 +29,7 @@ impl PackitPacket {
             name: packet.name.to_string(),
             parameters: packet.parameters.clone(),
             time: packet.time.clone(),
+            custom: packet.custom.clone(),
         }
     }
 }

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -278,6 +278,13 @@ async fn can_list_metadata() {
         1503074938.2232
     );
     assert_eq!(
+        entries[0].get("custom").unwrap().as_object().unwrap()
+            .get("orderly").unwrap().as_object().unwrap()
+            .get("artefacts").unwrap().as_array().unwrap()[3]
+            .get("description").unwrap().as_str().unwrap(),
+        "Projected Coverage for routine immunisation in PINE countries"
+    );
+    assert_eq!(
         entries[1].get("id").unwrap().as_str().unwrap(),
         "20170818-164847-7574883b"
     );

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -278,23 +278,7 @@ async fn can_list_metadata() {
         1503074938.2232
     );
     assert_eq!(
-        entries[0]
-            .get("custom")
-            .unwrap()
-            .as_object()
-            .unwrap()
-            .get("orderly")
-            .unwrap()
-            .as_object()
-            .unwrap()
-            .get("artefacts")
-            .unwrap()
-            .as_array()
-            .unwrap()[3]
-            .get("description")
-            .unwrap()
-            .as_str()
-            .unwrap(),
+        entries[0]["custom"]["orderly"]["artefacts"][3]["description"],
         "Projected Coverage for routine immunisation in PINE countries"
     );
     assert_eq!(

--- a/tests/test_api.rs
+++ b/tests/test_api.rs
@@ -278,10 +278,23 @@ async fn can_list_metadata() {
         1503074938.2232
     );
     assert_eq!(
-        entries[0].get("custom").unwrap().as_object().unwrap()
-            .get("orderly").unwrap().as_object().unwrap()
-            .get("artefacts").unwrap().as_array().unwrap()[3]
-            .get("description").unwrap().as_str().unwrap(),
+        entries[0]
+            .get("custom")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .get("orderly")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .get("artefacts")
+            .unwrap()
+            .as_array()
+            .unwrap()[3]
+            .get("description")
+            .unwrap()
+            .as_str()
+            .unwrap(),
         "Projected Coverage for routine immunisation in PINE countries"
     );
     assert_eq!(


### PR DESCRIPTION
This brings the implementation of the API to be more in line with the spec as it was in the README: namely, the /packit/metadata endpoint will now pass on the 'custom' property as part of the response. (The README also didn't show that the 'time' property was being returned.)