### PR TITLE
Fix the outpack_server build.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -49,10 +49,10 @@ jobs:
         run: |
           python -m build --sdist
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: python-artifacts
+          name: python-artifacts-sdist
           path: dist
 
   build-wheels:
@@ -96,10 +96,10 @@ jobs:
               fi
             fi
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
-          name: python-artifacts
+          name: python-artifacts-wheel-${{ matrix.config.os }}-${{  matrix.config.target }}
           path: dist
 
   # This assumes a PyPI Trusted Publisher has been configure for the `outpack_query_parser` package.
@@ -119,9 +119,10 @@ jobs:
       id-token: write
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: python-artifacts
-          path: dist/
+          pattern: python-artifacts-*
+          path: dist
+          merge-multiple: true
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -135,7 +135,7 @@ pub fn get_metadata_from_date(root_path: &Path, from: Option<f64>) -> io::Result
                     location_meta
                         .iter()
                         .find(|&e| e.packet == entry.file_name().into_string().unwrap())
-                        .map_or(false, |e| e.time > time)
+                        .is_some_and(|e| e.time > time)
                 })
                 .map(|entry| read_metadata(entry.path()))
                 .collect::<io::Result<Vec<Packet>>>()?

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,8 +9,7 @@ lazy_static! {
 }
 
 pub fn is_packet(name: &OsString) -> bool {
-    let o = name.to_str();
-    o.map_or(false, is_packet_str)
+    name.to_str().is_some_and(is_packet_str)
 }
 
 pub fn is_packet_str(name: &str) -> bool {


### PR DESCRIPTION
GitHub has decomissioned upload-artifact v3 and is forcing everyone to use v4. These work in similar ways, except v4 doesn't allow multiple jobs to push to the same artifact name anymore. We need to use distinct names for each OS/architecture pair, and have the call to download-artifact pull and merge them all. This is based on the [cibuildwheel documentation][cibuildwheel].

A couple of clippy fixes along the way.

[cibuildwheel]: https://cibuildwheel.pypa.io/en/stable/deliver-to-pypi/