### PR TITLE
Report an error when pushing conflicting metadata.

### DIFF
--- a/src/responses.rs
+++ b/src/responses.rs
@@ -97,6 +97,7 @@ impl axum::response::IntoResponse for OutpackError {
             Some(ErrorKind::NotFound) => StatusCode::NOT_FOUND,
             Some(ErrorKind::InvalidInput) => StatusCode::BAD_REQUEST,
             Some(ErrorKind::UnexpectedEof) => StatusCode::BAD_REQUEST,
+            Some(ErrorKind::AlreadyExists) => StatusCode::CONFLICT,
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,9 @@ use cached::instant::SystemTime;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::ffi::OsString;
+use std::path::Path;
 use std::time::UNIX_EPOCH;
+use std::{fs, io, io::Write};
 
 lazy_static! {
     static ref ID_REG: Regex = Regex::new(r"^([0-9]{8}-[0-9]{6}-[[:xdigit:]]{8})$").unwrap();
@@ -20,10 +22,34 @@ pub fn time_as_num(time: SystemTime) -> f64 {
     (time.duration_since(UNIX_EPOCH).unwrap().as_millis() as f64) / 1000.0
 }
 
+/// Write a byte slice to disk.
+///
+/// Succeeds if the file already exists with identical contents.
+/// On the other hand, an AlreadyExists error is returned if the file exists with different contents.
+pub fn write_file_idempotent(path: &Path, contents: &[u8]) -> io::Result<()> {
+    match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+    {
+        Ok(mut f) => {
+            f.write_all(contents)?;
+        }
+        Err(err) if err.kind() == io::ErrorKind::AlreadyExists => {
+            if fs::read(path)? != contents {
+                return Err(err);
+            }
+        }
+        Err(err) => return Err(err),
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::time::Duration;
+    use tempfile::tempdir;
 
     #[test]
     fn can_detect_packet_id() {
@@ -38,5 +64,43 @@ mod tests {
         let time = UNIX_EPOCH + Duration::from_millis(epoch_ms);
         let res = time_as_num(time);
         assert_eq!(res, 1688033668.123);
+    }
+
+    #[test]
+    fn write_file_idempotent_writes_to_disk() {
+        let base = tempdir().unwrap();
+        let path = base.path().join("hello.txt");
+
+        write_file_idempotent(&path, b"Hello").unwrap();
+
+        let contents = fs::read(path).unwrap();
+        assert_eq!(contents, b"Hello");
+    }
+
+    #[test]
+    fn write_file_idempotent_succeeds_if_content_is_identical() {
+        let base = tempdir().unwrap();
+        let path = base.path().join("hello.txt");
+
+        fs::write(&path, b"Hello").unwrap();
+
+        write_file_idempotent(&path, b"Hello").unwrap();
+
+        let contents = fs::read(path).unwrap();
+        assert_eq!(contents, b"Hello");
+    }
+
+    #[test]
+    fn write_file_idempotent_succeeds_if_content_is_different() {
+        let base = tempdir().unwrap();
+        let path = base.path().join("hello.txt");
+
+        fs::write(&path, b"Hello").unwrap();
+
+        let error = write_file_idempotent(&path, b"World").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+
+        let contents = fs::read(path).unwrap();
+        assert_eq!(contents, b"Hello");
     }
 }


### PR DESCRIPTION
Our packet IDs are generally assumed to be globally unique, but this is not guaranteed by construction: the ID is not a hash of its contents, and the metadata store is not content-addressed.

This means one could try to upload two different packets to the store with the same ID. Previously, outpack server would accept the second request but skip writing to the file. It is better to detect this situation and to return an HTTP error when it occurs.