### PR TITLE
Add io-util feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outpack"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.70"
 build = "build.rs"
@@ -26,7 +26,7 @@ anyhow = "1.0.75"
 thiserror = "1.0.50"
 pyo3 = { version = "0.20.0", features = ["extension-module", "abi3-py38"], optional = true }
 prometheus = { version = "0.13.3", features = ["process"] }
-tokio = { version = "1.35.1", features = ["fs", "rt-multi-thread"] }
+tokio = { version = "1.35.1", features = ["fs", "rt-multi-thread", "io-util"] }
 axum = "0.7.4"
 tracing-subscriber = "0.3.18"
 tracing = "0.1.40"


### PR DESCRIPTION
Failing to install for me with:

```
cargo install --git https://github.com/mrc-ide/outpack_server outpack
```

with error

```
error[E0432]: unresolved import `tokio::io::AsyncWriteExt`
   --> src/upload.rs:10:5
    |
10  | use tokio::io::AsyncWriteExt;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^ no `AsyncWriteExt` in `io`
    |
note: found an item that was configured out
   --> /home/rich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/io/mod.rs:277:159
    |
277 | ... AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt,
    |                                                  ^^^^^^^^^^^^^
note: the item is gated behind the `io-util` feature
   --> /home/rich/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.44.2/src/io/mod.rs:268:1
    |
268 | / cfg_io_util! {
269 | |     mod split;
270 | |     pub use split::{split, ReadHalf, WriteHalf};
271 | |     mod join;
...   |
279 | |     };
280 | | }
    | |_^
    = note: this error originates in the macro `cfg_io_util` (in Nightly builds, run with -Z macro-backtrace for more info)
```