### PR TITLE
Add additional metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outpack"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.70"
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outpack"
-version = "0.3.3"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.70"
 build = "build.rs"

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,9 +8,6 @@ use std::result::Result;
 use crate::hash::HashAlgorithm;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct Empty {}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Location {
     // Practically, doing anything with locations (therefore needing
     // access to the "type" and "args" fields) is going to require we

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::fs;
 use std::io::Error;
 use std::path::Path;
@@ -60,7 +61,7 @@ impl Config {
         let local = Location {
             name: String::from("local"),
             loc_type: String::from("local"),
-            args: Empty {},
+            args: HashMap::new(),
         };
         let location: Vec<Location> = vec![local];
         Ok(Config { core, location })

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct Location {
     pub name: String,
     #[serde(rename = "type")]
     pub loc_type: String,
-    pub args: Empty,
+    pub args: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -101,8 +101,8 @@ mod tests {
     fn can_write_config() {
         let cfg = Config::new(None, true, true).unwrap();
         assert_eq!(cfg.location.len(), 1);
-        assert_eq!(cfg.location[0].name, String::from("local"));
-        assert_eq!(cfg.location[0].loc_type, String::from("local"));
+        assert_eq!(cfg.location[0].name, "local");
+        assert_eq!(cfg.location[0].loc_type, "local");
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path();
         fs::create_dir_all(path.join(".outpack")).unwrap();

--- a/tests/bad-example/.outpack/config.json
+++ b/tests/bad-example/.outpack/config.json
@@ -10,7 +10,7 @@
     {
       "name": "another",
       "type": "file",
-      "args": []
+      "args": {}
     }
   ]
 }

--- a/tests/example/.outpack/config.json
+++ b/tests/example/.outpack/config.json
@@ -10,12 +10,12 @@
     {
       "name": "local",
       "type": "local",
-      "args": []
+      "args": {}
     },
     {
       "name": "another",
       "type": "file",
-      "args": []
+      "args": {}
     }
   ]
 }


### PR DESCRIPTION
We need a location entry for orderly2 to be able to interact with the outpack archive, at least for things like migrating data.  This PR adds the "local" location, which orderly treats specially (to the point where it cannot add it).

Metadata on initialisation, after this PR:

```
{
  "core": {
    "hash_algorithm": "sha256",
    "path_archive": null,
    "use_file_store": true,
    "require_complete_tree": false
  },
  "location": [
    {
      "name": "local",
      "type": "local",
      "args": {}
    }
  ]
}
```

Currently the `location` section is the empty list.