### PR TITLE
Bump Python version matrix.

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -12,10 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
-          - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "outpack_query_parser"
 readme = "README.python.md"
+dynamic = ["version"]
 
 [build-system]
 requires = ["maturin>=1.0,<2.0"]

--- a/src/query/query_eval.rs
+++ b/src/query/query_eval.rs
@@ -130,7 +130,7 @@ fn evaluate_lookup<'a>(
 }
 
 impl Packet {
-    pub fn lookup_value(&self, lookup: &PacketLookup) -> Option<Literal> {
+    pub fn lookup_value(&self, lookup: &PacketLookup) -> Option<Literal<'_>> {
         match lookup {
             PacketLookup::Id => Some(Literal::String(&self.id)),
             PacketLookup::Name => Some(Literal::String(&self.name)),
@@ -138,7 +138,7 @@ impl Packet {
         }
     }
 
-    pub fn get_parameter(&self, param_name: &str) -> Option<Literal> {
+    pub fn get_parameter(&self, param_name: &str) -> Option<Literal<'_>> {
         if let Some(params) = &self.parameters {
             match params.get(param_name)? {
                 JsonValue::Number(number) => Some(Literal::Number(number.as_f64()?)),

--- a/src/query/query_parse.rs
+++ b/src/query/query_parse.rs
@@ -10,7 +10,7 @@ use crate::query::ParseError;
 #[grammar = "query/query.pest"]
 struct QueryParser;
 
-pub fn parse_query(query: &str) -> Result<QueryNode, ParseError> {
+pub fn parse_query(query: &str) -> Result<QueryNode<'_>, ParseError> {
     let pairs = QueryParser::parse(Rule::query, query)?;
     let node = parse_toplevel(get_first_inner_pair(pairs.peek().unwrap()))?;
     Ok(node)
@@ -177,7 +177,7 @@ fn unknown_infix_error(operator: Pair<Rule>) -> ParseError {
     .into()
 }
 
-fn get_string_inner(rule: Pair<Rule>) -> &str {
+fn get_string_inner(rule: Pair<'_, Rule>) -> &str {
     get_first_inner_pair(rule).as_str()
 }
 

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -1,7 +1,0 @@
-import sys
-
-collect_ignore = []
-
-if sys.version_info < (3, 10):
-    # This test uses pattern matching, which isn't supported in older Python versions.
-    collect_ignore.append("test_pattern_match.py")


### PR DESCRIPTION
Python 3.8 and 3.9 are EOL. Add Python 3.12-3.14.

The pattern matching test can now be run unconditionally since all our Python versions support its syntax now.